### PR TITLE
[no-ticket] fix: don't always populate OR_GrowthRateFloor variable

### DIFF
--- a/tz/osemosys/model/variables/capacity.py
+++ b/tz/osemosys/model/variables/capacity.py
@@ -28,8 +28,9 @@ def add_capacity_variables(ds: xr.Dataset, m: Model) -> Model:
     )
     m.add_variables(lower=0, upper=inf, coords=RTeY, name="NewCapacity", integer=False)
 
-    if ("CapacityAdditionalMaxFloor" in ds.data_vars) and (
-        "CapacityAdditionalMaxGrowthRate" in ds.data_vars
+    if (
+        ds["CapacityAdditionalMaxFloor"].notnull().any()
+        and ds["CapacityAdditionalMaxGrowthRate"].notnull().any()
     ):
         m.add_variables(
             lower=0,


### PR DESCRIPTION
### Description
- only populate `OR_GrowthRateFloor` variable if the user has specified these constraints (otherwise the dual values are 0.)

### Checklist
- [ ] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible);
- [ ] All tests passing;
- [ ] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [ ] Extended the README, documentation and/or docstrings, if necessary;
