### PR TITLE
fix: github urls were missing a dash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,10 @@ dev = [
 
 
 [project.urls]  # Optional
-"Homepage" = "https://github.com/transitionzero/tz-osemosys"
-"Bug Reports" = "https://github.com/transitionzero/tz-osemosys/issues"
+"Homepage" = "https://github.com/transition-zero/tz-osemosys"
+"Bug Reports" = "https://github.com/transition-zero/tz-osemosys/issues"
 "Funding" = "https://transitionzero.org"
-"Source" = "https://github.com/transitionzero/tz-osemosys"
+"Source" = "https://github.com/transition-zero/tz-osemosys"
 
 # The following would provide a command line executable called `sample`
 # which executes the function `main` from this package when invoked.


### PR DESCRIPTION
Fix the URLS; you can see they are broken presently on PyPi - https://pypi.org/project/tz-osemosys/