### PR TITLE
Noticket mincapacityfactors

### DIFF
--- a/docs/technology.md
+++ b/docs/technology.md
@@ -43,6 +43,11 @@ Capacity available per each timeslice, expressed as a fraction of the total inst
 with values ranging from 0 to 1. It gives the possibility to account for forced outages.
 Optional, defaults to 1.
 
+`capacity_factor_annual_min` `({region:{year:float}})` - OSeMOSYS style name
+TotalAnnualMinCapacityFactor. Must run capacity constraint at annual level expressed as a
+fraction of the total installed capacity, with values ranging from 0 to 1. Optional, defaults
+to `None`.
+
 `capacity_one_tech_unit` `({region:{year:float}})` - OSeMOSYS CapacityOfOneTechnologyUnit.
 Capacity of one new unit of a technology. In case the user sets this parameter, the related
 technology will be installed only in batches of the specified capacity and the problem will

--- a/tests/test_solve/test_min_capacity_factors.py
+++ b/tests/test_solve/test_min_capacity_factors.py
@@ -1,0 +1,55 @@
+from tz.osemosys import Commodity, Model, OperatingMode, Region, Technology, TimeDefinition
+
+
+def test_min_capacity_factors():
+    """
+    In this model, we expect generators to be built 10GW per year until 20% of gross capacity >10GW
+    This should occur in 2026, when 20% of 60GW = 12GW.
+    Meanwhile, unmet demand should be unconstrained to build to meet the demand of 100GW.
+    """
+
+    time_definition = TimeDefinition(id="yrs", years=range(2020, 2030))
+    regions = [Region(id="single-region")]
+    commodities = [Commodity(id="electricity", demand_annual=100)]
+    impacts = []
+    technologies = [
+        Technology(
+            id="generator",
+            operating_life=20,  # years
+            capex=0.1,
+            operating_modes=[
+                OperatingMode(
+                    id="generation", opex_variable=0.0, output_activity_ratio={"electricity": 1.0}
+                )
+            ],
+        ),
+        Technology(
+            id="unmet-demand",
+            operating_life=1,
+            capex=0.1,
+            capacity_additional_min=10,
+            capacity_factor_annual_min=0.2,
+            operating_modes=[
+                OperatingMode(
+                    id="generation",
+                    opex_variable=100.0,
+                    output_activity_ratio={"electricity": 1.0},
+                ),
+            ],
+        ),
+    ]
+
+    model = Model(
+        id="simple-additional-capacity",
+        time_definition=time_definition,
+        regions=regions,
+        commodities=commodities,
+        impacts=impacts,
+        technologies=technologies,
+    )
+
+    model.solve()
+    breakpoint()
+    # assert model.solution.NewCapacity.sel(YEAR=2026, TECHNOLOGY="generator") == 12.0
+    # assert model.solution.NewCapacity.sel(YEAR=2020, TECHNOLOGY="unmet-demand") == 90.0
+

--- a/tests/test_solve/test_min_capacity_factors.py
+++ b/tests/test_solve/test_min_capacity_factors.py
@@ -3,9 +3,8 @@ from tz.osemosys import Commodity, Model, OperatingMode, Region, Technology, Tim
 
 def test_min_capacity_factors():
     """
-    In this model, we expect generators to be built 10GW per year until 20% of gross capacity >10GW
-    This should occur in 2026, when 20% of 60GW = 12GW.
-    Meanwhile, unmet demand should be unconstrained to build to meet the demand of 100GW.
+    In this model, we force the expensive 'unmet-demand' technology to be built at 10 GW per year,
+     with operating life of 1, and then utilised with a capacity_factor_annual_min of 0.2 (20%).
     """
 
     time_definition = TimeDefinition(id="yrs", years=range(2020, 2030))
@@ -40,7 +39,7 @@ def test_min_capacity_factors():
     ]
 
     model = Model(
-        id="simple-additional-capacity",
+        id="simple-min-capacity-factors",
         time_definition=time_definition,
         regions=regions,
         commodities=commodities,
@@ -49,7 +48,8 @@ def test_min_capacity_factors():
     )
 
     model.solve()
-    breakpoint()
-    # assert model.solution.NewCapacity.sel(YEAR=2026, TECHNOLOGY="generator") == 12.0
-    # assert model.solution.NewCapacity.sel(YEAR=2020, TECHNOLOGY="unmet-demand") == 90.0
 
+    assert (
+        model.solution["TotalTechnologyAnnualActivity"].sel(YEAR=2025, TECHNOLOGY="unmet-demand")
+        == 2
+    )

--- a/tz/osemosys/model/constraints/__init__.py
+++ b/tz/osemosys/model/constraints/__init__.py
@@ -4,7 +4,7 @@ import xarray as xr
 from linopy import LinearExpression, Model
 
 from .annual_activity import add_annual_activity_constraints
-from .annual_capacity_factor import add_annual_capacity_factor_constraints
+from .annual_capacity_factor_min import add_annual_capacity_factor_min_constraints
 from .capacity_adequacy_a import add_capacity_adequacy_a_constraints
 from .capacity_adequacy_b import add_capacity_adequacy_b_constraints
 from .capacity_growth_rate import add_capacity_growthrate_constraints
@@ -50,6 +50,6 @@ def add_constraints(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]) 
     m = add_total_capacity_constraints(ds, m, lex)
     m = add_capacity_growthrate_constraints(ds, m, lex)
     m = add_trade_constraints(ds, m, lex)
-    m = add_annual_capacity_factor_constraints(ds, m, lex)
+    m = add_annual_capacity_factor_min_constraints(ds, m, lex)
 
     return m

--- a/tz/osemosys/model/constraints/__init__.py
+++ b/tz/osemosys/model/constraints/__init__.py
@@ -4,6 +4,7 @@ import xarray as xr
 from linopy import LinearExpression, Model
 
 from .annual_activity import add_annual_activity_constraints
+from .annual_capacity_factor import add_annual_capacity_factor_constraints
 from .capacity_adequacy_a import add_capacity_adequacy_a_constraints
 from .capacity_adequacy_b import add_capacity_adequacy_b_constraints
 from .capacity_growth_rate import add_capacity_growthrate_constraints
@@ -49,5 +50,6 @@ def add_constraints(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]) 
     m = add_total_capacity_constraints(ds, m, lex)
     m = add_capacity_growthrate_constraints(ds, m, lex)
     m = add_trade_constraints(ds, m, lex)
+    m = add_annual_capacity_factor_constraints(ds, m, lex)
 
     return m

--- a/tz/osemosys/model/constraints/annual_capacity_factor.py
+++ b/tz/osemosys/model/constraints/annual_capacity_factor.py
@@ -8,7 +8,7 @@ def add_annual_capacity_factor_constraints(
     ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]
 ) -> Model:
     """Add annual capacity factor constraints to the model.
-    Constrains annual activity of a technology based on 
+    Constrains annual activity of a technology based on
     user-defined minimum utilisation rates.
 
     Arguments
@@ -25,17 +25,18 @@ def add_annual_capacity_factor_constraints(
 
     Notes
     -----
-    ```ampl     
+    ```ampl
     s.t ACF1_TotalAnnualMinCapacityFactor{
         r in REGION, t in TECHNOLOGY, y in YEAR: TotalAnnualMinCapacityFactor[r,t,y] > 0}:
         TotalTechnologyAnnualActivity[r,t,y] >=
         (GrossCapacity[r,t,y] * AvailabilityFactor[r,t,y] * CapacityToActivityUnit[r,t])
-        * TotalAnnualMinCapacityFactor[r,t,y]; 
+        * TotalAnnualMinCapacityFactor[r,t,y];
     ```
     """
-    #breakpoint()
-    con = lex["TotalTechnologyAnnualActivity"] >= ds["TotalAnnualMinCapacityFactor"] * (lex["GrossCapacity"] * ds["AvailabilityFactor"] * ds["CapacityToActivityUnit"])
-         
+    con = lex["TotalTechnologyAnnualActivity"] >= ds["TotalAnnualMinCapacityFactor"] * (
+        lex["GrossCapacity"] * ds["AvailabilityFactor"] * ds["CapacityToActivityUnit"]
+    )
+
     m.add_constraints(con, name="ACF1_TotalAnnualMinCapacityFactor")
-    
+
     return m

--- a/tz/osemosys/model/constraints/annual_capacity_factor.py
+++ b/tz/osemosys/model/constraints/annual_capacity_factor.py
@@ -1,0 +1,41 @@
+from typing import Dict
+
+import xarray as xr
+from linopy import LinearExpression, Model
+
+
+def add_annual_capacity_factor_constraints(
+    ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]
+) -> Model:
+    """Add annual capacity factor constraints to the model.
+    Constrains annual activity of a technology based on 
+    user-defined minimum utilisation rates.
+
+    Arguments
+    ---------
+    ds: xarray.Dataset
+        The parameters dataset
+    m: linopy.Model
+        A linopy model
+
+    Returns
+    -------
+    linopy.Model
+
+
+    Notes
+    -----
+    ```ampl     
+    s.t ACF1_TotalAnnualMinCapacityFactor{
+        r in REGION, t in TECHNOLOGY, y in YEAR: TotalAnnualMinCapacityFactor[r,t,y] > 0}:
+        TotalTechnologyAnnualActivity[r,t,y] >=
+        (GrossCapacity[r,t,y] * AvailabilityFactor[r,t,y] * CapacityToActivityUnit[r,t])
+        * TotalAnnualMinCapacityFactor[r,t,y]; 
+    ```
+    """
+    #breakpoint()
+    con = lex["TotalTechnologyAnnualActivity"] >= ds["TotalAnnualMinCapacityFactor"] * (lex["GrossCapacity"] * ds["AvailabilityFactor"] * ds["CapacityToActivityUnit"])
+         
+    m.add_constraints(con, name="ACF1_TotalAnnualMinCapacityFactor")
+    
+    return m

--- a/tz/osemosys/model/constraints/annual_capacity_factor_min.py
+++ b/tz/osemosys/model/constraints/annual_capacity_factor_min.py
@@ -4,7 +4,7 @@ import xarray as xr
 from linopy import LinearExpression, Model
 
 
-def add_annual_capacity_factor_constraints(
+def add_annual_capacity_factor_min_constraints(
     ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]
 ) -> Model:
     """Add annual capacity factor constraints to the model.

--- a/tz/osemosys/model/variables/activity.py
+++ b/tz/osemosys/model/variables/activity.py
@@ -33,7 +33,7 @@ def add_activity_variables(ds: xr.Dataset, m: Model) -> Model:
         ds.coords["TIMESLICE"],
     ]
 
-    mask = ds["InputActivityRatio"].notnull().any(dim="FUEL") | ds["OutputActivityRatio"].notnull().any(dim="FUEL") | ds["EmissionActivityRatio"].notnull().any(dim="EMISSION")
+    mask = ds["InputActivityRatio"].notnull().any(dim="FUEL") | ds["OutputActivityRatio"].notnull().any(dim="FUEL") | ds["EmissionActivityRatio"].notnull().any(dim="EMISSION") | ds["TechnologyToStorage"].notnull().any(dim="STORAGE") | ds["TechnologyFromStorage"].notnull().any(dim="STORAGE")
     m.add_variables(lower=0, upper=inf, coords=RTeMYTi, name="RateOfActivity", integer=False, mask=mask)
 
     m.add_variables(lower=0, upper=inf, coords=RRTiFY, name="Export", integer=False)

--- a/tz/osemosys/model/variables/activity.py
+++ b/tz/osemosys/model/variables/activity.py
@@ -33,7 +33,8 @@ def add_activity_variables(ds: xr.Dataset, m: Model) -> Model:
         ds.coords["TIMESLICE"],
     ]
 
-    m.add_variables(lower=0, upper=inf, coords=RTeMYTi, name="RateOfActivity", integer=False)
+    mask = ds["InputActivityRatio"].notnull().any(dim="FUEL") | ds["OutputActivityRatio"].notnull().any(dim="FUEL") | ds["EmissionActivityRatio"].notnull().any(dim="EMISSION")
+    m.add_variables(lower=0, upper=inf, coords=RTeMYTi, name="RateOfActivity", integer=False, mask=mask)
 
     m.add_variables(lower=0, upper=inf, coords=RRTiFY, name="Export", integer=False)
     m.add_variables(lower=0, upper=inf, coords=RRTiFY, name="Import", integer=False)

--- a/tz/osemosys/model/variables/activity.py
+++ b/tz/osemosys/model/variables/activity.py
@@ -33,8 +33,16 @@ def add_activity_variables(ds: xr.Dataset, m: Model) -> Model:
         ds.coords["TIMESLICE"],
     ]
 
-    mask = ds["InputActivityRatio"].notnull().any(dim="FUEL") | ds["OutputActivityRatio"].notnull().any(dim="FUEL") | ds["EmissionActivityRatio"].notnull().any(dim="EMISSION") | ds["TechnologyToStorage"].notnull().any(dim="STORAGE") | ds["TechnologyFromStorage"].notnull().any(dim="STORAGE")
-    m.add_variables(lower=0, upper=inf, coords=RTeMYTi, name="RateOfActivity", integer=False, mask=mask)
+    mask = (
+        ds["InputActivityRatio"].notnull().any(dim="FUEL")
+        | ds["OutputActivityRatio"].notnull().any(dim="FUEL")
+        | ds["EmissionActivityRatio"].notnull().any(dim="EMISSION")
+        | ds["TechnologyToStorage"].notnull().any(dim="STORAGE")
+        | ds["TechnologyFromStorage"].notnull().any(dim="STORAGE")
+    )
+    m.add_variables(
+        lower=0, upper=inf, coords=RTeMYTi, name="RateOfActivity", integer=False, mask=mask
+    )
 
     m.add_variables(lower=0, upper=inf, coords=RRTiFY, name="Export", integer=False)
     m.add_variables(lower=0, upper=inf, coords=RRTiFY, name="Import", integer=False)

--- a/tz/osemosys/schemas/compat/technology.py
+++ b/tz/osemosys/schemas/compat/technology.py
@@ -53,7 +53,7 @@ class OtooleTechnology(BaseModel):
         "TotalAnnualMinCapacityFactor": {
             "attribute": "capacity_factor_annual_min",
             "columns": ["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
-        },        
+        },
         "OperationalLife": {
             "attribute": "operating_life",
             "columns": ["REGION", "TECHNOLOGY", "VALUE"],
@@ -360,7 +360,7 @@ class OtooleTechnology(BaseModel):
                         OSeMOSYSData.RY(data=data_json_format["TotalAnnualMinCapacityFactor"])
                         if data_json_format["TotalAnnualMinCapacityFactor"] is not None
                         else None
-                    ),                        
+                    ),
                     include_in_joint_renewable_target=(
                         OSeMOSYSData.RY.Bool(data=data_json_format["RETagTechnology"])
                         if data_json_format["RETagTechnology"] is not None
@@ -434,7 +434,6 @@ class OtooleTechnology(BaseModel):
                             df["MODE_OF_OPERATION"] = mode.id
                             columns = [
                                 c
-                                
                                 for c in cls.otoole_stems[stem]["columns"]
                                 if c not in ["TECHNOLOGY", "VALUE", "MODE_OF_OPERATION"]
                             ]

--- a/tz/osemosys/schemas/compat/technology.py
+++ b/tz/osemosys/schemas/compat/technology.py
@@ -50,6 +50,10 @@ class OtooleTechnology(BaseModel):
             "attribute": "capacity_factor",
             "columns": ["REGION", "TECHNOLOGY", "YEAR", "TIMESLICE", "VALUE"],
         },
+        "TotalAnnualMinCapacityFactor": {
+            "attribute": "capacity_factor_annual_min",
+            "columns": ["REGION", "TECHNOLOGY", "YEAR", "VALUE"],
+        },        
         "OperationalLife": {
             "attribute": "operating_life",
             "columns": ["REGION", "TECHNOLOGY", "VALUE"],
@@ -352,6 +356,11 @@ class OtooleTechnology(BaseModel):
                         is not None
                         else None
                     ),
+                    capacity_factor_annual_min=(
+                        OSeMOSYSData.RY(data=data_json_format["TotalAnnualMinCapacityFactor"])
+                        if data_json_format["TotalAnnualMinCapacityFactor"] is not None
+                        else None
+                    ),                        
                     include_in_joint_renewable_target=(
                         OSeMOSYSData.RY.Bool(data=data_json_format["RETagTechnology"])
                         if data_json_format["RETagTechnology"] is not None

--- a/tz/osemosys/schemas/compat/technology.py
+++ b/tz/osemosys/schemas/compat/technology.py
@@ -434,6 +434,7 @@ class OtooleTechnology(BaseModel):
                             df["MODE_OF_OPERATION"] = mode.id
                             columns = [
                                 c
+                                
                                 for c in cls.otoole_stems[stem]["columns"]
                                 if c not in ["TECHNOLOGY", "VALUE", "MODE_OF_OPERATION"]
                             ]

--- a/tz/osemosys/schemas/technology.py
+++ b/tz/osemosys/schemas/technology.py
@@ -160,10 +160,11 @@ class Technology(OSeMOSYSBase, OtooleTechnology):
     Capacity available per each timeslice, expressed as a fraction of the total installed capacity,
     with values ranging from 0 to 1. It gives the possibility to account for forced outages.
     Optional, defaults to 1.
-    
-    `capacity_factor_annual_min` `({region:{year:float}})` - OSeMOSYS TotalAnnualMinCapacityFactor.
-    Must run capacity constraint at annual level expressed as a fraction of the total installed capacity,
-    with values ranging from 0 to 1. Optional, defaults to `None`.   
+
+    `capacity_factor_annual_min` `({region:{year:float}})` - OSeMOSYS style name
+    TotalAnnualMinCapacityFactor. Must run capacity constraint at annual level expressed as a
+    fraction of the total installed capacity, with values ranging from 0 to 1. Optional, defaults
+    to `None`.
 
     `capacity_one_tech_unit` `({region:{year:float}})` - OSeMOSYS CapacityOfOneTechnologyUnit.
     Capacity of one new unit of a technology. In case the user sets this parameter, the related
@@ -300,14 +301,13 @@ class Technology(OSeMOSYSBase, OtooleTechnology):
     # upper bound floor: if used with growth_rate,
     # limits capacity growth to the floor or growth-rate, whichever is greater
     capacity_additional_max_floor: OSeMOSYSData.R | None = Field(None)
-    
+
     # lower bound on capacity utilisation
     capacity_factor_annual_min: OSeMOSYSData.RY | None = Field(None)
 
     # additional capacity lower bounds (MUST build)
     capacity_additional_min: OSeMOSYSData.RY | None = Field(None)
     capacity_additional_min_growth_rate: OSeMOSYSData.R | None = Field(None)
-    
 
     # activity
     activity_annual_max: OSeMOSYSData.RY | None = Field(None)

--- a/tz/osemosys/schemas/technology.py
+++ b/tz/osemosys/schemas/technology.py
@@ -160,6 +160,10 @@ class Technology(OSeMOSYSBase, OtooleTechnology):
     Capacity available per each timeslice, expressed as a fraction of the total installed capacity,
     with values ranging from 0 to 1. It gives the possibility to account for forced outages.
     Optional, defaults to 1.
+    
+    `capacity_factor_annual_min` `({region:{year:float}})` - OSeMOSYS TotalAnnualMinCapacityFactor.
+    Must run capacity constraint at annual level expressed as a fraction of the total installed capacity,
+    with values ranging from 0 to 1. Optional, defaults to `None`.   
 
     `capacity_one_tech_unit` `({region:{year:float}})` - OSeMOSYS CapacityOfOneTechnologyUnit.
     Capacity of one new unit of a technology. In case the user sets this parameter, the related
@@ -296,10 +300,14 @@ class Technology(OSeMOSYSBase, OtooleTechnology):
     # upper bound floor: if used with growth_rate,
     # limits capacity growth to the floor or growth-rate, whichever is greater
     capacity_additional_max_floor: OSeMOSYSData.R | None = Field(None)
+    
+    # lower bound on capacity utilisation
+    capacity_factor_annual_min: OSeMOSYSData.RY | None = Field(None)
 
     # additional capacity lower bounds (MUST build)
     capacity_additional_min: OSeMOSYSData.RY | None = Field(None)
     capacity_additional_min_growth_rate: OSeMOSYSData.R | None = Field(None)
+    
 
     # activity
     activity_annual_max: OSeMOSYSData.RY | None = Field(None)


### PR DESCRIPTION
### Description

- Added a minimum annual capacity factor constraint for technologies
- This allows user to define a minimum utilisation or "must-run" condition which can be useful for a number of reasons:

1. It allows model to better reflect operational constraints of certain technologies (e.g. some thermal techs are not flexible enough to allow capacity factor to fluctuate between 0 and 100%)
2. If a reserve margin is defined it prevents the model from oversizing the system with capacity which remains dormant
3. It can help calibrate the model in the initial years where historical data is available (e.g. force certain technologies to operate to calibrate consumption and emissions, especially if not "optimal")

The minimum annual capacity factor has been checked both in the test python scripts and with larger models including a toy hydrogen model and a 3 node model of the Philippines.
   
### Checklist
- [ ] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible);
- [ ] All tests passing;
- [ ] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [ ] Extended the README, documentation and/or docstrings, if necessary;
