### PR TITLE
Revert curl syntax to work on ubuntu default curl

### DIFF
--- a/.github/workflows/tz-solve-osemosys-build-webhook.yml
+++ b/.github/workflows/tz-solve-osemosys-build-webhook.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - name: Trigger webhook
       run: |
-        curl --json "{}" "${{ secrets.TZ_SOLVE_OSEMOSYS_BUILD_WEBHOOK }}"
+        curl -X POST -H "Content-Type: application/json" -d "{}" "${{ secrets.TZ_SOLVE_OSEMOSYS_BUILD_WEBHOOK }}"


### PR DESCRIPTION
### Description
ubuntu-latest doesn't like --json option in curl

### Checklist
- [ ] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible);
- [ ] All tests passing;
- [ ] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [ ] Extended the README, documentation and/or docstrings, if necessary;
