### PR TITLE
[ENG-1694]: Fix storage memory

### DIFF
--- a/tests/test_integration/test_linopy_model.py
+++ b/tests/test_integration/test_linopy_model.py
@@ -24,7 +24,7 @@ def test_linopy_model():
 
             model = Model.from_otoole_csv(sample_path)
 
-            model.solve()
+            model.solve(solver="highs")
 
             ref_results_df = pd.read_csv(Path(results_path) / "TotalDiscountedCost.csv")
 

--- a/tests/test_solve/test_growth_rates.py
+++ b/tests/test_solve/test_growth_rates.py
@@ -80,7 +80,7 @@ def test_growth_rate_floor():
         technologies=technologies,
     )
 
-    model.solve()
+    model.solve(solver="highs")
 
     assert model.solution.NewCapacity.sel(YEAR=2022, TECHNOLOGY="generator") == 0.0606
     assert model.solution.NewCapacity.sel(YEAR=2020, TECHNOLOGY="unmet-demand") == 99.0
@@ -134,7 +134,7 @@ def test_growth_rate_ceil():
         technologies=technologies,
     )
 
-    model.solve()
+    model.solve(solver="highs")
 
     assert model.solution.NewCapacity.sel(YEAR=2021, TECHNOLOGY="generator") == 15.0
     assert model.solution.NewCapacity.sel(YEAR=2024, TECHNOLOGY="generator") == 20.0
@@ -201,7 +201,7 @@ def test_growth_rate_min():
         technologies=technologies,
     )
 
-    model.solve()
+    model.solve(solver="highs")
 
     assert model.solution.NewCapacity.sel(YEAR=2021, TECHNOLOGY="bad-generator") == 1.0
     assert model.solution.NewCapacity.sel(YEAR=2022, TECHNOLOGY="bad-generator") == 1.1

--- a/tests/test_solve/test_min_capacity_factors.py
+++ b/tests/test_solve/test_min_capacity_factors.py
@@ -47,7 +47,7 @@ def test_min_capacity_factors():
         technologies=technologies,
     )
 
-    model.solve()
+    model.solve(solver="highs")
 
     assert (
         model.solution["TotalTechnologyAnnualActivity"].sel(YEAR=2025, TECHNOLOGY="unmet-demand")

--- a/tests/test_solve/test_salvage.py
+++ b/tests/test_solve/test_salvage.py
@@ -33,7 +33,7 @@ def test_salvage_value_straight_line():
         technologies=technologies,
     )
 
-    model.solve()
+    model.solve(solver="highs")
 
     assert np.round(model.solution.DiscountedSalvageValue.sum().values) == 1203.0
 
@@ -68,6 +68,6 @@ def test_salvage_value_sinking_fund():
         technologies=technologies,
     )
 
-    model.solve()
+    model.solve(solver="highs")
 
     assert np.round(model.solution.DiscountedSalvageValue.sum().values) == 1349.0

--- a/tests/test_solve/test_solve.py
+++ b/tests/test_solve/test_solve.py
@@ -17,7 +17,7 @@ def test_model_construction_from_yaml():
     model._m.solve(solver_name="highs")
 
     assert model._m.termination_condition == "optimal"
-    assert np.round(model._m.objective.value) == 29042.0
+    assert np.round(model._m.objective.value) == 29044.0
 
 
 def test_model_solve_from_otoole_csv():

--- a/tests/test_solve/test_solve.py
+++ b/tests/test_solve/test_solve.py
@@ -14,10 +14,10 @@ def test_model_construction_from_yaml():
 
     model._build()
 
-    model._m.solve()
+    model._m.solve(solver_name="highs")
 
     assert model._m.termination_condition == "optimal"
-    assert np.round(model._m.objective.value) == 29044.0
+    assert np.round(model._m.objective.value) == 29042.0
 
 
 def test_model_solve_from_otoole_csv():
@@ -28,7 +28,7 @@ def test_model_solve_from_otoole_csv():
     path = "examples/otoole_compat/input_csv/otoole-simple-hydro"
 
     model = Model.from_otoole_csv(path)
-    model.solve()
+    model.solve(solver="highs")
 
     assert model._m.termination_condition == "optimal"
     assert np.round(model._m.objective.value) == 5591653.0
@@ -59,7 +59,7 @@ def test_most_simple():
 
     model._build()
 
-    model._m.solve()
+    model._m.solve(solver_name="highs")
 
     assert model._m.termination_condition == "optimal"
     assert np.round(model._m.objective.value) == 45736.0
@@ -182,7 +182,7 @@ def test_simple_storage():
         storage=storage,
         technologies=technologies,
     )
-    model.solve()
+    model.solve(solver="highs")
 
     assert model.solution.NewStorageCapacity.values[0][0][0] == 12.5
     assert model.solution.NetCharge[0][1][0][0] == 75  # bat-storage 2020 Day charge
@@ -235,7 +235,7 @@ def test_simple_trade():
         ],
     )
 
-    model.solve()
+    model.solve(solver="highs")
 
     assert model.solution["NetTrade"].values[0][2][0] == 15
     assert np.round(model._m.objective.value) == 28200.0
@@ -288,7 +288,7 @@ def test_simple_re_target():
 
     model._build()
 
-    model._m.solve()
+    model._m.solve(solver_name="highs")
 
     assert model._m.termination_condition == "optimal"
     assert np.round(model._m.objective.value) == 54671.0

--- a/tz/osemosys/model/constraints/re_targets.py
+++ b/tz/osemosys/model/constraints/re_targets.py
@@ -53,12 +53,7 @@ def add_re_targets_constraints(ds: xr.Dataset, m: Model, lex: Dict[str, LinearEx
         UseByTechnologyAnnual[r,t,f,y];
     ```
     """
-
-    con = (
-        lex["ProductionAnnualRE"]
-        >= lex["ProductionAnnual"].assign_coords({"FUEL": ds["RETagFuel"] == 1})
-        * ds["REMinProductionTarget"]
-    )
+    con = lex["ProductionAnnualRE"] >= lex["ProductionAnnual"] * ds["REMinProductionTarget"]
     mask = ds["RETagFuel"] == 1
     m.add_constraints(con, name="RE1_RenewableProduction_MinConstraint", mask=mask)
 

--- a/tz/osemosys/model/linear_expressions/capacity.py
+++ b/tz/osemosys/model/linear_expressions/capacity.py
@@ -11,7 +11,7 @@ def add_lex_capacity(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression])
         ds.YEAR - NewCapacity.data.BUILDYEAR < ds.OperationalLife
     )
 
-    AccumulatedNewCapacity = NewCapacity.where(mask, drop=False).sum("BUILDYEAR")
+    AccumulatedNewCapacity = NewCapacity.where(mask).sum("BUILDYEAR")
 
     GrossCapacity = AccumulatedNewCapacity + ds["ResidualCapacity"].fillna(0)
 

--- a/tz/osemosys/model/linear_expressions/capacity.py
+++ b/tz/osemosys/model/linear_expressions/capacity.py
@@ -11,7 +11,7 @@ def add_lex_capacity(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression])
         ds.YEAR - NewCapacity.data.BUILDYEAR < ds.OperationalLife
     )
 
-    AccumulatedNewCapacity = NewCapacity.where(mask).sum("BUILDYEAR")
+    AccumulatedNewCapacity = NewCapacity.where(mask, drop=False).sum("BUILDYEAR")
 
     GrossCapacity = AccumulatedNewCapacity + ds["ResidualCapacity"].fillna(0)
 

--- a/tz/osemosys/model/linear_expressions/emissions.py
+++ b/tz/osemosys/model/linear_expressions/emissions.py
@@ -8,18 +8,19 @@ def add_lex_emissions(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]
     AnnualTechnologyEmissionByMode = (
         (ds["EmissionActivityRatio"] * ds["YearSplit"] * m["RateOfActivity"])
         .sum("TIMESLICE")
-        .where(ds["EmissionActivityRatio"].notnull())
+        .where(ds["EmissionActivityRatio"].notnull(), drop=False)
     )
 
     AnnualTechnologyEmission = AnnualTechnologyEmissionByMode.sum(dims="MODE_OF_OPERATION").where(
-        ds["EmissionActivityRatio"].sum("MODE_OF_OPERATION") != 0
+        ds["EmissionActivityRatio"].sum("MODE_OF_OPERATION") != 0, drop=False
     )
 
     AnnualTechnologyEmissionPenaltyByEmission = (
         AnnualTechnologyEmission * ds["EmissionsPenalty"]
     ).where(
         ds["EmissionsPenalty"].notnull()
-        & (ds["EmissionActivityRatio"].sum("MODE_OF_OPERATION") != 0)
+        & (ds["EmissionActivityRatio"].sum("MODE_OF_OPERATION") != 0),
+        drop=False,
     )
 
     AnnualTechnologyEmissionsPenalty = AnnualTechnologyEmissionPenaltyByEmission.sum(

--- a/tz/osemosys/model/linear_expressions/financials.py
+++ b/tz/osemosys/model/linear_expressions/financials.py
@@ -5,7 +5,6 @@ from linopy import LinearExpression, Model
 
 
 def add_lex_financials(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
-
     CapitalInvestment = (
         ds["CapitalCost"].fillna(0)
         * m["NewCapacity"]
@@ -21,7 +20,8 @@ def add_lex_financials(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression
         .sum(dims="MODE_OF_OPERATION")
         .where(
             (ds["VariableCost"].sum(dim="MODE_OF_OPERATION") != 0)
-            & (~ds["VariableCost"].sum(dim="MODE_OF_OPERATION").isnull())
+            & (~ds["VariableCost"].sum(dim="MODE_OF_OPERATION").isnull()),
+            drop=True,
         )
     )
     AnnualFixedOperatingCost = lex["GrossCapacity"] * ds["FixedCost"].fillna(0)
@@ -38,8 +38,8 @@ def add_lex_financials(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression
     DiscountedCapitalInvestment = CapitalInvestment / lex["DiscountFactor"]
 
     SalvageValue = (
-        m["NewCapacity"] * SV1Cost.where(lex["sv1_mask"])
-        + m["NewCapacity"] * SV2Cost.where(lex["sv2_mask"])
+        m["NewCapacity"] * SV1Cost.where(lex["sv1_mask"], drop=True)
+        + m["NewCapacity"] * SV2Cost.where(lex["sv2_mask"], drop=True)
     ).fillna(0)
 
     DiscountedSalvageValue = SalvageValue / lex["DiscountFactorSalvage"]

--- a/tz/osemosys/model/linear_expressions/financials.py
+++ b/tz/osemosys/model/linear_expressions/financials.py
@@ -21,7 +21,7 @@ def add_lex_financials(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression
         .where(
             (ds["VariableCost"].sum(dim="MODE_OF_OPERATION") != 0)
             & (~ds["VariableCost"].sum(dim="MODE_OF_OPERATION").isnull()),
-            drop=True,
+            drop=False,
         )
     )
     AnnualFixedOperatingCost = lex["GrossCapacity"] * ds["FixedCost"].fillna(0)
@@ -38,8 +38,8 @@ def add_lex_financials(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression
     DiscountedCapitalInvestment = CapitalInvestment / lex["DiscountFactor"]
 
     SalvageValue = (
-        m["NewCapacity"] * SV1Cost.where(lex["sv1_mask"], drop=True)
-        + m["NewCapacity"] * SV2Cost.where(lex["sv2_mask"], drop=True)
+        m["NewCapacity"] * SV1Cost.where(lex["sv1_mask"], drop=False)
+        + m["NewCapacity"] * SV2Cost.where(lex["sv2_mask"], drop=False)
     ).fillna(0)
 
     DiscountedSalvageValue = SalvageValue / lex["DiscountFactorSalvage"]

--- a/tz/osemosys/model/linear_expressions/production.py
+++ b/tz/osemosys/model/linear_expressions/production.py
@@ -7,10 +7,10 @@ from linopy import LinearExpression, Model
 def add_lex_quantities(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
     # Production
     RateOfProductionByTechnologyByMode = m["RateOfActivity"] * ds["OutputActivityRatio"].where(
-        ds["OutputActivityRatio"].notnull()
+        ds["OutputActivityRatio"].notnull(), drop=False
     )
     RateOfProductionByTechnology = RateOfProductionByTechnologyByMode.where(
-        ds["OutputActivityRatio"].sum("MODE_OF_OPERATION") != 0
+        ds["OutputActivityRatio"].sum("MODE_OF_OPERATION") != 0, drop=False
     ).sum(dims="MODE_OF_OPERATION")
     RateOfProduction = RateOfProductionByTechnology.sum(dims="TECHNOLOGY")
     ProductionByTechnology = RateOfProductionByTechnology * ds["YearSplit"]
@@ -18,10 +18,10 @@ def add_lex_quantities(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression
     ProductionAnnual = Production.sum(dims="TIMESLICE")
 
     RateOfUseByTechnologyByMode = m["RateOfActivity"] * ds["InputActivityRatio"].where(
-        ds["InputActivityRatio"].notnull()
+        ds["InputActivityRatio"].notnull(), drop=False
     )
     RateOfUseByTechnology = RateOfUseByTechnologyByMode.where(
-        ds["InputActivityRatio"].sum("MODE_OF_OPERATION") != 0
+        ds["InputActivityRatio"].sum("MODE_OF_OPERATION") != 0, drop=False
     ).sum(dims="MODE_OF_OPERATION")
     RateOfUse = RateOfUseByTechnology.sum(dims="TECHNOLOGY")
     Use = RateOfUse * ds["YearSplit"]

--- a/tz/osemosys/model/linear_expressions/re_production.py
+++ b/tz/osemosys/model/linear_expressions/re_production.py
@@ -6,10 +6,10 @@ from linopy import LinearExpression, Model
 
 def add_lex_re_production(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
     RateOfProductionByTechnologyByModeRE = m["RateOfActivity"] * ds["OutputActivityRatio"].where(
-        ds["OutputActivityRatio"].notnull() & (ds["RETagTechnology"] == 1), drop=True
+        ds["OutputActivityRatio"].notnull() & (ds["RETagTechnology"] == 1), drop=False
     )
     RateOfProductionByTechnologyRE = RateOfProductionByTechnologyByModeRE.where(
-        ds["OutputActivityRatio"].sum("MODE_OF_OPERATION") != 0, drop=True
+        ds["OutputActivityRatio"].sum("MODE_OF_OPERATION") != 0, drop=False
     ).sum(dims="MODE_OF_OPERATION")
     RateOfProductionRE = RateOfProductionByTechnologyRE.sum(dims="TECHNOLOGY")
     ProductionByTechnologyRE = RateOfProductionByTechnologyRE * ds["YearSplit"]

--- a/tz/osemosys/model/linear_expressions/re_production.py
+++ b/tz/osemosys/model/linear_expressions/re_production.py
@@ -5,12 +5,11 @@ from linopy import LinearExpression, Model
 
 
 def add_lex_re_production(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
-
     RateOfProductionByTechnologyByModeRE = m["RateOfActivity"] * ds["OutputActivityRatio"].where(
-        ds["OutputActivityRatio"].notnull() & (ds["RETagTechnology"] == 1)
+        ds["OutputActivityRatio"].notnull() & (ds["RETagTechnology"] == 1), drop=True
     )
     RateOfProductionByTechnologyRE = RateOfProductionByTechnologyByModeRE.where(
-        ds["OutputActivityRatio"].sum("MODE_OF_OPERATION") != 0
+        ds["OutputActivityRatio"].sum("MODE_OF_OPERATION") != 0, drop=True
     ).sum(dims="MODE_OF_OPERATION")
     RateOfProductionRE = RateOfProductionByTechnologyRE.sum(dims="TECHNOLOGY")
     ProductionByTechnologyRE = RateOfProductionByTechnologyRE * ds["YearSplit"]

--- a/tz/osemosys/model/linear_expressions/reserve_margin.py
+++ b/tz/osemosys/model/linear_expressions/reserve_margin.py
@@ -11,7 +11,8 @@ def add_lex_reserve_margin(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpres
         ).where(
             (ds["ReserveMargin"] > 0)
             & (ds["ReserveMarginTagTechnology"] == 1)
-            & (ds["ReserveMarginTagTechnology"] * ds["CapacityToActivityUnit"]).notnull()
+            & (ds["ReserveMarginTagTechnology"] * ds["CapacityToActivityUnit"]).notnull(),
+            drop=False,
         )
     ).sum("TECHNOLOGY")
 
@@ -21,7 +22,8 @@ def add_lex_reserve_margin(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpres
         (ds["OutputActivityRatio"].notnull())
         & (ds["ReserveMargin"] > 0)
         & (ds["ReserveMarginTagFuel"] == 1)
-        & (ds["ReserveMarginTagTechnology"] == 1)
+        & (ds["ReserveMarginTagTechnology"] == 1),
+        drop=False,
     )
 
     RateOfProductionByTechnologyWithReserveMargin = (
@@ -29,7 +31,8 @@ def add_lex_reserve_margin(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpres
             (ds["OutputActivityRatio"].notnull())
             & (ds["ReserveMargin"] > 0)
             & (ds["ReserveMarginTagFuel"] == 1)
-            & (ds["ReserveMarginTagTechnology"] == 1)
+            & (ds["ReserveMarginTagTechnology"] == 1),
+            drop=False,
         ).sum(dims="MODE_OF_OPERATION")
     )
 
@@ -37,12 +40,13 @@ def add_lex_reserve_margin(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpres
         (ds["OutputActivityRatio"].notnull())
         & (ds["ReserveMargin"] > 0)
         & (ds["ReserveMarginTagFuel"] == 1)
-        & (ds["ReserveMarginTagTechnology"] == 1)
+        & (ds["ReserveMarginTagTechnology"] == 1),
+        drop=False,
     ).sum(dims="TECHNOLOGY")
 
     DemandNeedingReserveMargin = (
         (lex["RateOfProduction"] * ds["ReserveMarginTagFuel"])
-        .where((ds["ReserveMargin"] > 0) & (ds["ReserveMarginTagFuel"] == 1))
+        .where((ds["ReserveMargin"] > 0) & (ds["ReserveMarginTagFuel"] == 1), drop=False)
         .sum("FUEL")
     )
 

--- a/tz/osemosys/model/linear_expressions/storage.py
+++ b/tz/osemosys/model/linear_expressions/storage.py
@@ -70,7 +70,7 @@ def add_lex_storage(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
         ds.YEAR - NewStorageCapacity.data.BUILDYEAR < ds.OperationalLifeStorage
     )
 
-    AccumulatedNewStorageCapacity = NewStorageCapacity.where(mask, drop=False).sum("BUILDYEAR")
+    AccumulatedNewStorageCapacity = NewStorageCapacity.where(mask).sum("BUILDYEAR")
 
     GrossStorageCapacity = AccumulatedNewStorageCapacity + ds["ResidualStorageCapacity"]
 
@@ -86,8 +86,8 @@ def add_lex_storage(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
     )
 
     SalvageValueStorage = (
-        m["NewStorageCapacity"] * SV1CostStorage.where(lex["sv1_mask"], drop=True)
-        + m["NewStorageCapacity"] * SV2CostStorage.where(lex["sv2_mask"], drop=True)
+        m["NewStorageCapacity"] * SV1CostStorage.where(lex["sv1_mask"], drop=False)
+        + m["NewStorageCapacity"] * SV2CostStorage.where(lex["sv2_mask"], drop=False)
     ).fillna(0)
 
     DiscountedSalvageValueStorage = SalvageValueStorage / DiscountFactorStorage

--- a/tz/osemosys/model/linear_expressions/storage.py
+++ b/tz/osemosys/model/linear_expressions/storage.py
@@ -12,7 +12,7 @@ def add_lex_storage(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
 
     RateOfStorageCharge = (
         (ds["TechnologyToStorage"] * m["RateOfActivity"]).where(
-            (ds["TechnologyToStorage"].notnull()) & (ds["TechnologyToStorage"] != 0)
+            (ds["TechnologyToStorage"].notnull()) & (ds["TechnologyToStorage"] != 0), drop=True
         )
     ).sum(["TECHNOLOGY", "MODE_OF_OPERATION"])
 
@@ -35,7 +35,7 @@ def add_lex_storage(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
 
     RateOfStorageDischarge = (
         (ds["TechnologyFromStorage"] * m["RateOfActivity"]).where(
-            (ds["TechnologyFromStorage"].notnull()) & (ds["TechnologyFromStorage"] != 0)
+            (ds["TechnologyFromStorage"].notnull()) & (ds["TechnologyFromStorage"] != 0), drop=True
         )
     ).sum(["TECHNOLOGY", "MODE_OF_OPERATION"])
 

--- a/tz/osemosys/model/linear_expressions/trade.py
+++ b/tz/osemosys/model/linear_expressions/trade.py
@@ -10,13 +10,13 @@ def add_lex_trade(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
     mask = (ds.YEAR - NewTradeCapacity.data.BUILDYEAR >= 0) & (
         ds.YEAR - NewTradeCapacity.data.BUILDYEAR < ds.OperationalLifeTrade
     )
-    AccumulatedNewTradeCapacity = NewTradeCapacity.where(mask, drop=False).sum("BUILDYEAR")
+    AccumulatedNewTradeCapacity = NewTradeCapacity.where(mask).sum("BUILDYEAR")
     GrossTradeCapacity = AccumulatedNewTradeCapacity + ds["ResidualTradeCapacity"].fillna(0)
 
     # Activity #
     NetTrade = (
         ((m["Export"] / (1 - ds["TradeLossBetweenRegions"])) - m["Import"])
-        .where(ds["TradeRoute"].notnull(), drop=True)
+        .where(ds["TradeRoute"].notnull(), drop=False)
         .sum("_REGION")
         .fillna(0)
     )
@@ -86,8 +86,8 @@ def add_lex_trade(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
 
     # salvage value (trade)
     SalvageValueTrade = (
-        m["NewTradeCapacity"] * SV1CostTrade.where(sv1_trade_mask, drop=True)
-        + m["NewTradeCapacity"] * SV2CostTrade.where(sv2_trade_mask, drop=True)
+        m["NewTradeCapacity"] * SV1CostTrade.where(sv1_trade_mask, drop=False)
+        + m["NewTradeCapacity"] * SV2CostTrade.where(sv2_trade_mask, drop=False)
     ).fillna(0)
 
     DiscountedSalvageValueTrade = SalvageValueTrade / DiscountFactorSalvageTrade

--- a/tz/osemosys/model/linear_expressions/trade.py
+++ b/tz/osemosys/model/linear_expressions/trade.py
@@ -5,19 +5,18 @@ from linopy import LinearExpression, Model
 
 
 def add_lex_trade(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
-
     # Capacity #
     NewTradeCapacity = m["NewTradeCapacity"].rename(YEAR="BUILDYEAR")
     mask = (ds.YEAR - NewTradeCapacity.data.BUILDYEAR >= 0) & (
         ds.YEAR - NewTradeCapacity.data.BUILDYEAR < ds.OperationalLifeTrade
     )
-    AccumulatedNewTradeCapacity = NewTradeCapacity.where(mask).sum("BUILDYEAR")
+    AccumulatedNewTradeCapacity = NewTradeCapacity.where(mask, drop=False).sum("BUILDYEAR")
     GrossTradeCapacity = AccumulatedNewTradeCapacity + ds["ResidualTradeCapacity"].fillna(0)
 
     # Activity #
     NetTrade = (
         ((m["Export"] / (1 - ds["TradeLossBetweenRegions"])) - m["Import"])
-        .where(ds["TradeRoute"].notnull())
+        .where(ds["TradeRoute"].notnull(), drop=True)
         .sum("_REGION")
         .fillna(0)
     )
@@ -87,8 +86,8 @@ def add_lex_trade(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
 
     # salvage value (trade)
     SalvageValueTrade = (
-        m["NewTradeCapacity"] * SV1CostTrade.where(sv1_trade_mask)
-        + m["NewTradeCapacity"] * SV2CostTrade.where(sv2_trade_mask)
+        m["NewTradeCapacity"] * SV1CostTrade.where(sv1_trade_mask, drop=True)
+        + m["NewTradeCapacity"] * SV2CostTrade.where(sv2_trade_mask, drop=True)
     ).fillna(0)
 
     DiscountedSalvageValueTrade = SalvageValueTrade / DiscountFactorSalvageTrade


### PR DESCRIPTION
### Description
Drop masked coefficients via `.where(..., drop=True)` in linear expressions for `RateOfStorageCharge` and `RateOfStorageDischarge`. This significantly reduces memory consumption for `StorageLevel` computation which uses the `LinearExpression.cumsum` method.

The plot below shows an approximately 90% reduction in memory consumption for one model as a result of this change

![image](https://github.com/user-attachments/assets/964165e7-1034-4289-bbd6-3b071aba29c4)

Additionally add in `drop=False` to other linear expressions masking (which is just verbose for the default behaviour) as a placeholder for future potential memory optimisations to be applied. These changes will require further refactoring to deal with misaligned dimensions/coordinates after dropping masked coefficients.

Lastly make tests explicitly use `"highs"` solver.

#### NOTE:

With `drop=False` the memory consumption of the `StorageLevel` expressions scales as:

`O(TECHNOLOGIES * OPERATING_MODES * TIMESLICES)`

whereas with `drop=True` this effectively becomes:

`O(STORAGE_TECHNOLOGIES * STORAGE_OPERATING_MODES * TIMESLICES)`

therefore models with a relatively large number of storage technologies / operating modes will still suffer from high memory consumption. To avoid this entirely, the call to `LinearExpression.cumsum` should be replaced with something else.

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible);
- [x] All tests passing;
- [x] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [ ] Extended the README, documentation and/or docstrings, if necessary;
