### PR TITLE
[ENG-2082] fix bugs when dumping model to json and reloading into model

### DIFF
--- a/tz/osemosys/schemas/compat/time_definition.py
+++ b/tz/osemosys/schemas/compat/time_definition.py
@@ -249,7 +249,7 @@ class OtooleTimeDefinition(BaseModel):
                             "YEAR": year,
                             "VALUE": self.day_split[dtb],
                         }
-                        for dtb, year in product(self.daily_time_brackets, self.years)
+                        for dtb, year in product(list(self.day_split.keys()), self.years)
                     ]
                 )
                 if self.daily_time_brackets is not None

--- a/tz/osemosys/schemas/validation/timedefinition_validation.py
+++ b/tz/osemosys/schemas/validation/timedefinition_validation.py
@@ -120,7 +120,7 @@ def validate_parts_from_splits(timeslices, day_types, time_brackets, values):
         if split is not None:
             if part_list is not None:
                 # validate keys match
-                if {str(item) for item in set(split.keys())} != set(part_list):
+                if {str(item) for item in set(split.keys())} != {str(item) for item in part_list}:
                     raise ValueError(f"provided '{name}_split' keys do not match '{name}'")
                 return split
             else:
@@ -158,41 +158,43 @@ def validate_adjacency_keys(
     if {int(yr) for yr in list(adj["years"].keys()) + list(adj["years"].values())} != set(years):
         raise ValueError("provided 'years' do not match keys or values of 'adj.years'")
     if seasons is not None and "seasons" in adj.keys():
-        if len(seasons) > 1:
-            if set(list(adj["seasons"].keys()) + list(adj["seasons"].values())) != set(seasons):
-                raise ValueError("provided 'seasons' do not match keys or values of 'adj.seasons'")
-        else:
-            if adj["seasons"] != {}:
+        if adj["seasons"] != {}:
+            if len(seasons) > 1:
+                if set(list(adj["seasons"].keys()) + list(adj["seasons"].values())) != set(seasons):
+                    raise ValueError(
+                        "provided 'seasons' do not match keys or values of 'adj.seasons'"
+                    )
+            else:
                 raise ValueError(
                     f"Adjacency provided for seasons, but only one season {seasons} is defined."
                 )
     elif seasons is not None or adj.get("seasons"):
         raise ValueError("seasons provided without adjacency.")
     if day_types is not None and "day_types" in adj.keys():
-        if len(day_types) > 1:
-            if set(list(adj["day_types"].keys()) + list(adj["day_types"].values())) != set(
-                day_types
-            ):
-                raise ValueError(
-                    "provided 'day_types' do not match keys or values of 'adj.day_types'"
-                )
-        else:
-            if adj["day_types"] != {}:
+        if adj["day_types"] != {}:
+            if len(day_types) > 1:
+                if set(list(adj["day_types"].keys()) + list(adj["day_types"].values())) != set(
+                    day_types
+                ):
+                    raise ValueError(
+                        "provided 'day_types' do not match keys or values of 'adj.day_types'"
+                    )
+            else:
                 raise ValueError(
                     f"Adjacency provided for day_types, but only one day_type {day_types} is defined."  # NOQA E501
                 )
     elif day_types is not None or adj.get("day_types"):
         raise ValueError("day_types provided without adjacency")
     if time_brackets is not None and "time_brackets" in adj.keys():
-        if len(time_brackets) > 1:
-            if set(list(adj["time_brackets"].keys()) + list(adj["time_brackets"].values())) != set(
-                time_brackets
-            ):
-                raise ValueError(
-                    "provided 'time_brackets' do not match keys or values of 'adj.time_brackets'"
-                )
-        else:
-            if adj["time_brackets"] != {}:
+        if adj["time_brackets"] != {}:
+            if len(time_brackets) > 1:
+                if set(
+                    list(adj["time_brackets"].keys()) + list(adj["time_brackets"].values())
+                ) != set(time_brackets):
+                    raise ValueError(
+                        "provided 'time_brackets' do not match keys or values of 'adj.time_brackets'"  # NOQA E501
+                    )
+            else:
                 raise ValueError(
                     f"Adjacency provided for time_brackets, but only one time_bracket {time_brackets} is defined."  # NOQA E501
                 )


### PR DESCRIPTION
### Description
Bugs were occuring when trying to dump an osemosys model to json, and then reload the model again from this json.

These bugs were due to some things being formatted as strings rather than int once being dumped to json.



objective costs are identical

### Checklist
- [ ] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible);
- [ ] All tests passing;
- [ ] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [ ] Extended the README, documentation and/or docstrings, if necessary;
