### PR TITLE
fix: solver name conflict

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -178,7 +178,7 @@ model.solve()
 
 By default, the model will be solved using the first available solver in the list of available
 solvers. To specify a solver, pass the name of the solver as a string to the solve() method for
-the argument `solver` (e.g. `model.solve(solver_name="highs")`).
+the argument `solver_name` (e.g. `model.solve(solver_name="highs")`).
 
 ### Viewing the model solution
 

--- a/docs/model.md
+++ b/docs/model.md
@@ -178,7 +178,7 @@ model.solve()
 
 By default, the model will be solved using the first available solver in the list of available
 solvers. To specify a solver, pass the name of the solver as a string to the solve() method for
-the argument `solver` (e.g. `model.solve(solver="highs")`).
+the argument `solver` (e.g. `model.solve(solver_name="highs")`).
 
 ### Viewing the model solution
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ cloudpath=[
 # package-data = {"sample" = ["*.dat"]}
 
 [tool.setuptools.packages]
-find = {}
+find = { include = ["tz.*"] }
 
 [build-system]
 # These are the assumed default build requirements from pip:

--- a/tests/test_integration/test_linopy_model.py
+++ b/tests/test_integration/test_linopy_model.py
@@ -24,7 +24,7 @@ def test_linopy_model():
 
             model = Model.from_otoole_csv(sample_path)
 
-            model.solve(solver="highs")
+            model.solve(solver_name="highs")
 
             ref_results_df = pd.read_csv(Path(results_path) / "TotalDiscountedCost.csv")
 

--- a/tests/test_solve/test_growth_rates.py
+++ b/tests/test_solve/test_growth_rates.py
@@ -80,7 +80,7 @@ def test_growth_rate_floor():
         technologies=technologies,
     )
 
-    model.solve(solver="highs")
+    model.solve(solver_name="highs")
 
     assert model.solution.NewCapacity.sel(YEAR=2022, TECHNOLOGY="generator") == 0.0606
     assert model.solution.NewCapacity.sel(YEAR=2020, TECHNOLOGY="unmet-demand") == 99.0
@@ -134,7 +134,7 @@ def test_growth_rate_ceil():
         technologies=technologies,
     )
 
-    model.solve(solver="highs")
+    model.solve(solver_name="highs")
 
     assert model.solution.NewCapacity.sel(YEAR=2021, TECHNOLOGY="generator") == 15.0
     assert model.solution.NewCapacity.sel(YEAR=2024, TECHNOLOGY="generator") == 20.0
@@ -201,7 +201,7 @@ def test_growth_rate_min():
         technologies=technologies,
     )
 
-    model.solve(solver="highs")
+    model.solve(solver_name="highs")
 
     assert model.solution.NewCapacity.sel(YEAR=2021, TECHNOLOGY="bad-generator") == 1.0
     assert model.solution.NewCapacity.sel(YEAR=2022, TECHNOLOGY="bad-generator") == 1.1

--- a/tests/test_solve/test_min_capacity_factors.py
+++ b/tests/test_solve/test_min_capacity_factors.py
@@ -47,7 +47,7 @@ def test_min_capacity_factors():
         technologies=technologies,
     )
 
-    model.solve(solver="highs")
+    model.solve(solver_name="highs")
 
     assert (
         model.solution["TotalTechnologyAnnualActivity"].sel(YEAR=2025, TECHNOLOGY="unmet-demand")

--- a/tests/test_solve/test_salvage.py
+++ b/tests/test_solve/test_salvage.py
@@ -33,7 +33,7 @@ def test_salvage_value_straight_line():
         technologies=technologies,
     )
 
-    model.solve(solver="highs")
+    model.solve(solver_name="highs")
 
     assert np.round(model.solution.DiscountedSalvageValue.sum().values) == 1203.0
 
@@ -68,6 +68,6 @@ def test_salvage_value_sinking_fund():
         technologies=technologies,
     )
 
-    model.solve(solver="highs")
+    model.solve(solver_name="highs")
 
     assert np.round(model.solution.DiscountedSalvageValue.sum().values) == 1349.0

--- a/tests/test_solve/test_solve.py
+++ b/tests/test_solve/test_solve.py
@@ -28,7 +28,7 @@ def test_model_solve_from_otoole_csv():
     path = "examples/otoole_compat/input_csv/otoole-simple-hydro"
 
     model = Model.from_otoole_csv(path)
-    model.solve(solver="highs")
+    model.solve(solver_name="highs")
 
     assert model._m.termination_condition == "optimal"
     assert np.round(model._m.objective.value) == 5591653.0
@@ -182,7 +182,7 @@ def test_simple_storage():
         storage=storage,
         technologies=technologies,
     )
-    model.solve(solver="highs")
+    model.solve(solver_name="highs")
 
     assert model.solution.NewStorageCapacity.values[0][0][0] == 12.5
     assert model.solution.NetCharge[0][1][0][0] == 75  # bat-storage 2020 Day charge
@@ -239,7 +239,7 @@ def test_simple_trade():
         ],
     )
 
-    model.solve(solver="highs")
+    model.solve(solver_name="highs")
 
     assert model.solution["NetTrade"].values[0][2][0] == 30
     assert np.round(model._m.objective.value) == 30387.0

--- a/tz/osemosys/model/model.py
+++ b/tz/osemosys/model/model.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Optional
 import xarray as xr
 from linopy import LinearExpression
 from linopy import Model as LPModel
-from linopy import available_solvers
 
 from tz.osemosys.io.load_model import load_cfg
 from tz.osemosys.model.constraints import add_constraints
@@ -272,24 +271,16 @@ class Model(RunSpec):
 
     def solve(
         self,
-        solver: str | None = None,
         lp_path: str | None = None,
         solution_vars: list[str] | str | None = None,
         **linopy_solve_kwargs: Any,
     ):
         self._build()
 
-        if solver is None:
-            solver = available_solvers[0]
-        else:
-            assert (
-                solver in available_solvers
-            ), f"Solver {solver} not available. Choose from {available_solvers}."
-
         if lp_path:
             self._m.to_file(lp_path)
 
-        self._m.solve(solver_name=solver, **linopy_solve_kwargs)
+        self._m.solve(**linopy_solve_kwargs)
 
         if self._m.termination_condition == "optimal":
             self._solution = self._get_solution(solution_vars)

--- a/tz/osemosys/model/model.py
+++ b/tz/osemosys/model/model.py
@@ -273,12 +273,12 @@ class Model(RunSpec):
     def solve(
         self,
         solution_vars: list[str] | str | None = None,
-        solver_options: dict[str, Any] = {},
+        solver_options: dict[str, Any] | None = None,
         **linopy_solve_kwargs: Any,
     ) -> tuple[str, str]:
         self._build()
 
-        self._m.solve(**solver_options, **linopy_solve_kwargs)
+        self._m.solve(**(solver_options or {}), **linopy_solve_kwargs)
 
         if self._m.termination_condition == "optimal":
             self._solution = self._get_solution(solution_vars)

--- a/tz/osemosys/model/model.py
+++ b/tz/osemosys/model/model.py
@@ -192,7 +192,7 @@ class Model(RunSpec):
 
     By default, the model will be solved using the first available solver in the list of available
     solvers. To specify a solver, pass the name of the solver as a string to the solve() method for
-    the argument `solver` (e.g. `model.solve(solver_name="highs")`).
+    the argument `solver_name` (e.g. `model.solve(solver_name="highs")`).
 
     ### Viewing the model solution
 

--- a/tz/osemosys/model/model.py
+++ b/tz/osemosys/model/model.py
@@ -192,7 +192,7 @@ class Model(RunSpec):
 
     By default, the model will be solved using the first available solver in the list of available
     solvers. To specify a solver, pass the name of the solver as a string to the solve() method for
-    the argument `solver` (e.g. `model.solve(solver="highs")`).
+    the argument `solver` (e.g. `model.solve(solver_name="highs")`).
 
     ### Viewing the model solution
 

--- a/tz/osemosys/model/objective.py
+++ b/tz/osemosys/model/objective.py
@@ -1,21 +1,16 @@
-from copy import deepcopy
-from typing import Dict
-
 from linopy import LinearExpression, Model
 
 
-def add_objective(m: Model, lex: Dict[str, LinearExpression]) -> Model:
-
+def add_objective(m: Model, lex: dict[str, LinearExpression]) -> float:
     objective = lex["TotalDiscountedCost"].sum(dims=["REGION", "YEAR"])
 
     # constants not currently supported in objective functions:
     # https://github.com/PyPSA/linopy/issues/236
     if (objective.const != 0).any():
-        objective_constant = deepcopy(objective.const)
-        objective.const = 0
+        objective_constant = objective.const.item()
+        objective.const.values = 0
     else:
         objective_constant = 0
 
     m.add_objective(expr=objective, overwrite=True)
-
     return objective_constant

--- a/tz/osemosys/model/solution.py
+++ b/tz/osemosys/model/solution.py
@@ -53,7 +53,7 @@ SOLUTION_KEYS = [
 
 def build_solution(
     m: Model, lex: Dict[str, LinearExpression], solution_vars: list[str] | str | None = None
-):
+) -> xr.Dataset:
 
     # construct duals separately
     duals = xr.Dataset(
@@ -126,17 +126,13 @@ def build_solution(
         )
 
     if solution_vars is None:
-        return xr.Dataset(
-            {
-                k: solution_base[k]
-                for k in sorted(list(solution_base.keys()))
-                if (k in SOLUTION_KEYS) and (k in solution_base.keys())
-            }
-        )
+        return solution_base[sorted(set(SOLUTION_KEYS) & set(solution_base.data_vars))]
     elif solution_vars == "all":
-        return xr.Dataset({k: solution_base[k] for k in sorted(list(solution_base.keys()))})
+        return solution_base[sorted(solution_base.data_vars)]
     else:
+        if isinstance(solution_vars, str):
+            solution_vars = [solution_vars]
         # ensure TotalDiscountedCost is always included
         if "TotalDiscountedCost" not in solution_vars:
             solution_vars.append("TotalDiscountedCost")
-        return xr.Dataset({k: solution_base[k] for k in solution_vars})
+        return solution_base[sorted(set(solution_vars) & set(solution_base.data_vars))]


### PR DESCRIPTION
### Description

Bug reported via slack:
```
also... I'm wondering how we pass in the solver option "solver"
e.g., in pypsa I do:
n.optimize(solver_name='highs', solver_options={'solver':'pdlp'})
in tz-osemosys this would be:
n.optimize(solver='highs', solver='pdlp')
which obviously does not work
```

This PR just lets linopy do its thing to handle the solver name and options. **It's a breaking change** because now you must call `model.solve(solver_name=...)` instead of `model.solve(solver=...)`.

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible);
- [x] All tests passing;
- [x] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [x] Extended the README, documentation and/or docstrings, if necessary;
