### PR TITLE
bypass time_definition.adj.years validation check if single year

### DIFF
--- a/tz/osemosys/schemas/validation/timedefinition_validation.py
+++ b/tz/osemosys/schemas/validation/timedefinition_validation.py
@@ -155,7 +155,9 @@ def validate_adjacency_keys(
         set(list(adj["timeslices"].keys()) + list(adj["timeslices"].values())) != set(timeslices)
     ):
         raise ValueError("provided 'timeslices' do not match keys or values of 'adj.timeslices'")
-    if {int(yr) for yr in list(adj["years"].keys()) + list(adj["years"].values())} != set(years):
+    if len(years) > 1 and {
+        int(yr) for yr in list(adj["years"].keys()) + list(adj["years"].values())
+    } != set(years):
         raise ValueError("provided 'years' do not match keys or values of 'adj.years'")
     if seasons is not None and "seasons" in adj.keys():
         if adj["seasons"] != {}:


### PR DESCRIPTION
### Description
Please explain the changes you made here.

### Checklist
- [ ] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible);
- [ ] All tests passing;
- [ ] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [ ] Extended the README, documentation and/or docstrings, if necessary;
