### PR TITLE
[ENG-3111] Decompose DiscountedOperatingCost

### DIFF
--- a/tz/osemosys/model/linear_expressions/financials.py
+++ b/tz/osemosys/model/linear_expressions/financials.py
@@ -33,7 +33,11 @@ def add_lex_financials(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression
     SV2Cost = ds["CapitalCost"].fillna(0) * (1 - (lex["SV2Numerator"] / lex["SV2Denominator"]))
 
     # costs
-    DiscountedOperatingCost = OperatingCost / lex["DiscountFactorMid"]
+    DiscountedAnnualFixedOperatingCost = AnnualFixedOperatingCost / lex["DiscountFactorMid"]
+    DiscountedAnnualVariableOperatingCost = AnnualVariableOperatingCost / lex["DiscountFactorMid"]
+    DiscountedOperatingCost = (
+        DiscountedAnnualVariableOperatingCost + DiscountedAnnualFixedOperatingCost
+    )
 
     DiscountedCapitalInvestment = CapitalInvestment / lex["DiscountFactor"]
 
@@ -80,6 +84,8 @@ def add_lex_financials(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression
             "AnnualVariableOperatingCost": AnnualVariableOperatingCost,
             "AnnualFixedOperatingCost": AnnualFixedOperatingCost,
             "OperatingCost": OperatingCost,
+            "DiscountedAnnualFixedOperatingCost": DiscountedAnnualFixedOperatingCost,
+            "DiscountedAnnualVariableOperatingCost": DiscountedAnnualVariableOperatingCost,
             "DiscountedOperatingCost": DiscountedOperatingCost,
             "DiscountedCapitalInvestment": DiscountedCapitalInvestment,
             "DiscountedSalvageValue": DiscountedSalvageValue,


### PR DESCRIPTION
### Description
Decompose `DiscountedOperatingCost` into two new variables and update the computation to sum these.

- Add `DiscountedAnnualFixedOperatingCost`
- Add `DiscountedAnnualVariableOperatingCost`
- Update operation in `DiscountedOperatingCost`
- Update return value to include the new variables

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible);
- [x] All tests passing;
- [x] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [x] Extended the README, documentation and/or docstrings, if necessary;
