### PR TITLE
[ENG-3242] add capacity annual max

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [  # Optional
 dependencies = [
   "pydantic>2",
   "pydantic-settings",
-  "xarray",
+  "xarray<2025.03.0",
   "orjson",
   "linopy",
 ]

--- a/tz/osemosys/schemas/technology.py
+++ b/tz/osemosys/schemas/technology.py
@@ -212,6 +212,8 @@ class Technology(OSeMOSYSBase, OtooleTechnology):
     technology's capacity year on year, expressed as a decimal (e.g. 0.2 for 20%). Optional,
     defaults to `None`.
 
+    `capacity_annual_max` `({region:{year:float}})` - OSeMOSYS TotalAnnualMaxCapacity.
+
     `activity_annual_max` `({region:{year:float}})` - OSeMOSYS
     TotalTechnologyAnnualActivityUpperLimit.
     Total maximum level of activity allowed for a technology in one year.
@@ -314,6 +316,8 @@ class Technology(OSeMOSYSBase, OtooleTechnology):
     # additional capacity lower bounds (MUST build)
     capacity_additional_min: OSeMOSYSData.RY | None = Field(None)
     capacity_additional_min_growth_rate: OSeMOSYSData.RY | None = Field(None)
+
+    capacity_annual_max: OSeMOSYSData.RY | None = Field(None)
 
     # activity
     activity_annual_max: OSeMOSYSData.RY | None = Field(None)


### PR DESCRIPTION
### Description
Add capacity annual max to `Technology` schema.

Fixed xarray version to address linopy bug (see [github issue 431](https://github.com/PyPSA/linopy/issues/431)). Latest version of `xarray` causes the following linopy error:

```bash
_______________ ERROR collecting tests/test_solve/test_solve.py ________________
ImportError while importing test module '/__w/tz-osemosys/tz-osemosys/tests/test_solve/test_solve.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/local/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_solve/test_solve.py:3: in <module>
    from tz.osemosys import Commodity, Model, OperatingMode, Region, Storage, Technology, TimeDefinition
tz/osemosys/__init__.py:10: in <module>
    from tz.osemosys.model.model import Model
tz/osemosys/model/model.py:4: in <module>
    from linopy import LinearExpression
/usr/local/lib/python3.11/site-packages/linopy/__init__.py:14: in <module>
    import linopy.monkey_patch_xarray  # noqa: F401
/usr/local/lib/python3.11/site-packages/linopy/monkey_patch_xarray.py:8: in <module>
    from linopy import expressions, variables
/usr/local/lib/python3.11/site-packages/linopy/expressions.py:28: in <module>
    import xarray.core.rolling
E   ModuleNotFoundError: No module named 'xarray.core.rolling'
```

### Checklist
- [ ] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible);
- [ ] All tests passing;
- [ ] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [ ] Extended the README, documentation and/or docstrings, if necessary;
