### PR TITLE
[NO-TICKET] revert attribute

### DIFF
--- a/tz/osemosys/schemas/technology.py
+++ b/tz/osemosys/schemas/technology.py
@@ -212,8 +212,6 @@ class Technology(OSeMOSYSBase, OtooleTechnology):
     technology's capacity year on year, expressed as a decimal (e.g. 0.2 for 20%). Optional,
     defaults to `None`.
 
-    `capacity_annual_max` `({region:{year:float}})` - OSeMOSYS TotalAnnualMaxCapacity.
-
     `activity_annual_max` `({region:{year:float}})` - OSeMOSYS
     TotalTechnologyAnnualActivityUpperLimit.
     Total maximum level of activity allowed for a technology in one year.
@@ -316,8 +314,6 @@ class Technology(OSeMOSYSBase, OtooleTechnology):
     # additional capacity lower bounds (MUST build)
     capacity_additional_min: OSeMOSYSData.RY | None = Field(None)
     capacity_additional_min_growth_rate: OSeMOSYSData.RY | None = Field(None)
-
-    capacity_annual_max: OSeMOSYSData.RY | None = Field(None)
 
     # activity
     activity_annual_max: OSeMOSYSData.RY | None = Field(None)


### PR DESCRIPTION
### Description
ENG-3242 has been rescoped to use `capacity_additional_max` instead of `capacity_annual_max` so removing the latter from `Technology` definition.


### Checklist
- [ ] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible);
- [ ] All tests passing;
- [ ] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [ ] Extended the README, documentation and/or docstrings, if necessary;
