### PR TITLE
feat: multiple tz-mod interoperability enhancements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "xarray",
   "orjson",
   "linopy",
+  "h5netcdf",
 ]
 
 

--- a/tz/osemosys/defaults.py
+++ b/tz/osemosys/defaults.py
@@ -43,7 +43,7 @@ class DefaultsLinopy(BaseSettings):
             "DiscountRate": 0.1,
             "ResidualCapacity": 0,
             "SpecifiedAnnualDemand": 0,
-            "TradeRoute": False,
+            "TradeRoute": int(False),  # boolean is invalid netcdf
         }
     )
 

--- a/tz/osemosys/model/model.py
+++ b/tz/osemosys/model/model.py
@@ -295,7 +295,7 @@ class Model(RunSpec):
             self._data = self._build_dataset()
         ds = self._data if self._solution is None else self._data.merge(self._solution)
         ds.to_netcdf(path, engine="h5netcdf")
-    
+
     def read_netcdf(self, path: str) -> None:
         raise NotImplementedError("Reading from netcdf is not implemented yet.")
 

--- a/tz/osemosys/model/model.py
+++ b/tz/osemosys/model/model.py
@@ -280,7 +280,7 @@ class Model(RunSpec):
 
         self._m.solve(**(solver_options or {}), **linopy_solve_kwargs)
 
-        if self._m.termination_condition == "optimal":
+        if self._m.status == "ok":
             self._solution = self._get_solution(solution_vars)
 
             # rather hacky - constants not currently supported in objective functions:
@@ -289,6 +289,15 @@ class Model(RunSpec):
             self._objective = self._solution.TotalDiscountedCost.sum().values
 
         return self._m.status, self._m.termination_condition
+
+    def save_netcdf(self, path: str) -> None:
+        if not hasattr(self, "_data"):
+            self._data = self._build_dataset()
+        ds = self._data if self._solution is None else self._data.merge(self._solution)
+        ds.to_netcdf(path, engine="h5netcdf")
+    
+    def read_netcdf(self, path: str) -> None:
+        raise NotImplementedError("Reading from netcdf is not implemented yet.")
 
     @property
     def solution(self):

--- a/tz/osemosys/model/model.py
+++ b/tz/osemosys/model/model.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Dict, Optional
 
 import xarray as xr
@@ -290,13 +291,13 @@ class Model(RunSpec):
 
         return self._m.status, self._m.termination_condition
 
-    def save_netcdf(self, path: str) -> None:
+    def save_netcdf(self, path: str | os.PathLike[str]) -> None:
         if not hasattr(self, "_data"):
             self._data = self._build_dataset()
         ds = self._data if self._solution is None else self._data.merge(self._solution)
         ds.to_netcdf(path, engine="h5netcdf")
 
-    def read_netcdf(self, path: str) -> None:
+    def read_netcdf(self, path: str | os.PathLike[str]):
         raise NotImplementedError("Reading from netcdf is not implemented yet.")
 
     @property

--- a/tz/osemosys/schemas/compat/trade.py
+++ b/tz/osemosys/schemas/compat/trade.py
@@ -352,6 +352,16 @@ class OtooleTrade(BaseModel):
             if capacity_activity_unit_ratio_dfs
             else pd.DataFrame(columns=cls.otoole_stems["TradeCapacityToActivityUnit"]["columns"])
         )
+        dfs["TradeRouteLookup"] = pd.DataFrame(
+            [
+                (r, _r, t.commodity, t.id)
+                for t in trade
+                if t.trade_routes is not None
+                for r in t.trade_routes.data
+                for _r in t.trade_routes.data[r]
+            ],
+            columns=["REGION", "_REGION", "FUEL", "VALUE"],
+        )
 
         return dfs
 


### PR DESCRIPTION
### Description

* Add a `save_netcdf` method (as well as a NotImplemented `read_netcdf`)
* Use linopy status instead of termination condition for solution assignment condition
* Cast trade route default boolean value to int for xarray/netcdf compatibility
* Add `TradeRouteLookup` variable

### Checklist
- [ ] Dependencies install correctly in a clean environment and code executes;
- [ ] Test coverage extended; created tests fail without the change (if possible);
- [ ] All tests passing;
- [ ] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [ ] Extended the README, documentation and/or docstrings, if necessary;
