### PR TITLE
Carbon price (dual solution) from region group emissions budget

### DIFF
--- a/tz/osemosys/model/solution.py
+++ b/tz/osemosys/model/solution.py
@@ -50,6 +50,7 @@ SOLUTION_KEYS = [
     "marginal_cost_of_demand_annual",
     "marginal_cost_of_emissions_total",
     "marginal_cost_of_emissions_annual",
+    "marginal_cost_of_emissions_annual_regiongroup"
 ]
 
 
@@ -75,6 +76,7 @@ def build_solution(
                 for key in [
                     "E8_AnnualEmissionsLimit",
                     "E9_ModelPeriodEmissionsLimit",
+                    "E10_AnnualEmmissionsLimitRegionGroup"
                 ]
                 if hasattr(m.constraints, key)
             }
@@ -95,17 +97,19 @@ def build_solution(
             )
         )
     )
-    if "E8_AnnualEmissionsLimit" in duals and "E9_ModelPeriodEmissionsLimit" in duals:
+    if "E8_AnnualEmissionsLimit" in duals and "E9_ModelPeriodEmissionsLimit" in duals and "E10_AnnualEmmissionsLimitRegionGroup in duals":
         duals = duals.rename(
             dict(
                 zip(
                     [
                         "E8_AnnualEmissionsLimit",
                         "E9_ModelPeriodEmissionsLimit",
+                        "E10_AnnualEmmissionsLimitRegionGroup",
                     ],
                     [
                         "marginal_cost_of_emissions_annual",
                         "marginal_cost_of_emissions_total",
+                        "marginal_cost_of_emissions_annual_region_group"
                     ],
                 )
             )


### PR DESCRIPTION
- Added region group emissions budget constraint into duals
- Allows direct output of region group carbon price (i.e. price of carbon budget)
