### PR TITLE
Fixed discounting PVAnnuity forumula as was calling discount rate idv…

### DIFF
--- a/tz/osemosys/model/linear_expressions/discounting.py
+++ b/tz/osemosys/model/linear_expressions/discounting.py
@@ -18,9 +18,9 @@ def add_lex_discounting(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpressio
     )
 
     PVAnnuity = (
-        (1 - (1 + ds["DiscountRateIdv"]) ** (-(ds["OperationalLife"])))
-        * (1 + ds["DiscountRateIdv"])
-        / ds["DiscountRateIdv"]
+        (1 - (1 + ds["DiscountRate"]) ** (-(ds["OperationalLife"])))
+        * (1 + ds["DiscountRate"])
+        / ds["DiscountRate"]
     )
 
     CapitalRecoveryFactor = (1 - (1 + ds["DiscountRateIdv"]) ** (-1)) / (


### PR DESCRIPTION
Fixed discounting PVAnnuity forumula as was calling discount rate idv which was cancelling out (i.e. was the inverse) of capital recovery factor when being multiplied together in capital investment formula


