### PR TITLE
[ENG-6039] Fix activity constraints for trades

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,10 @@ classifiers = [  # Optional
 ]
 
 dependencies = [
+  "pandas<3",
   "pydantic>2",
   "pydantic-settings",
+  "h5py",
   "xarray",
   "orjson",
   "linopy==0.5.5",

--- a/tests/test_solve/test_3_node_trade.py
+++ b/tests/test_solve/test_3_node_trade.py
@@ -9,8 +9,8 @@ def test_3_node_trade_export():
     surplus of 10 and no new capacity is allowed for trade or generation, so total
     export is capped at 10. Variable costs differ by region (R1=5, R2=10, R3=0; R3
     cheapest, R2 most expensive). Without a minimum per link then R1 would send
-    all 10 on the expensive R2 and 0 on the cheaper R3. A min capacity factor of
-    0.5 on each link requires at least 5 on each, so both links are used and the
+    all 10 to the expensive R2 and 0 to the cheaper R3. A min capacity factor of
+    0.5 for each link requires at least 5 to each, so both links are used and the
     solution is 5+5. The test asserts Export 5 and 5 on the two links, confirming
     that the minimum-flow constraints are applied correctly.
 

--- a/tests/test_solve/test_3_node_trade.py
+++ b/tests/test_solve/test_3_node_trade.py
@@ -1,0 +1,90 @@
+import numpy as np
+
+from tz.osemosys import Model
+
+
+def test_3_node_trade_export():
+    """
+    Three regions (R1, R2, R3) with R1 as sole exporter to R2 and R3. R1 has a fixed
+    surplus of 10 and no new capacity is allowed for trade or generation, so total
+    export is capped at 10. Variable costs differ by region (R1=5, R2=10, R3=0; R3
+    cheapest, R2 most expensive). Without a minimum per link then R1 would send
+    all 10 on the expensive R2 and 0 on the cheaper R3. A min capacity factor of
+    0.5 on each link requires at least 5 on each, so both links are used and the
+    solution is 5+5. The test asserts Export 5 and 5 on the two links, confirming
+    that the minimum-flow constraints are applied correctly.
+
+    Parameters
+    ----------
+    Regions R1, R2, R3; one commodity and one technology. R1 residual 60 and demand 50
+    (surplus 10), R2 and R3 residual and demand 50 each. Variable costs R1=5, R2=10,
+    R3=0. Both links capacity 10 with capacity_factor_annual_min 0.5.
+    capacity_additional_max 0 for trade and technology. Assertion: Export(R1→R2) and
+    Export(R1→R3) equal to 5 for the solved year.
+    """
+    model = Model(
+        id="test-3-node-trade",
+        time_definition=dict(id="years-only", years=range(2020, 2031)),
+        regions=[dict(id="R1"), dict(id="R2"), dict(id="R3")],
+        trade=[
+            dict(
+                id="electricity transmission",
+                commodity="electricity",
+                trade_routes={
+                    "R1": {"R2": {"*": True}, "R3": {"*": True}},
+                },
+                capex={
+                    "R1": {"R2": {"*": 100}, "R3": {"*": 100}},
+                },
+                operating_life={
+                    "R1": {"R2": {"*": 2}, "R3": {"*": 2}},
+                },
+                trade_loss={"*": {"*": {"*": 0}}},
+                residual_capacity={
+                    "R1": {"R2": {"*": 10}, "R3": {"*": 10}},
+                },
+                capacity_additional_max={
+                    "R1": {"R2": {"*": 0}, "R3": {"*": 0}},
+                },
+                cost_of_capital={"R1": {"R2": 0.1, "R3": 0.1}},
+                capacity_activity_unit_ratio=1,
+                capacity_factor_annual_min={
+                    "R1": {"R2": {"*": 0.5}, "R3": {"*": 0.5}},
+                },
+            )
+        ],
+        commodities=[dict(id="electricity", demand_annual=50)],
+        impacts=[],
+        technologies=[
+            dict(
+                id="coal-gen",
+                operating_life=2,
+                capex={"R1": {"*": 0}, "R2": {"*": 0}, "R3": {"*": 0}},
+                residual_capacity={
+                    "R1": {"*": 60},
+                    "R2": {"*": 50},
+                    "R3": {"*": 50},
+                },
+                capacity_additional_max={"R1": {"*": 0}, "R2": {"*": 0}, "R3": {"*": 0}},
+                operating_modes=[
+                    dict(
+                        id="generation",
+                        opex_variable={
+                            "R1": {"*": 5},
+                            "R2": {"*": 10},
+                            "R3": {"*": 0},
+                        },
+                        output_activity_ratio={"electricity": 1},
+                    )
+                ],
+            )
+        ],
+    )
+
+    model.solve(solver_name="highs")
+
+    export = model.solution["Export"].sel(YEAR=2020)
+    r1_to_r2 = export.sel(REGION="R1", _REGION="R2").sum(dim=["TIMESLICE", "FUEL"]).item()
+    r1_to_r3 = export.sel(REGION="R1", _REGION="R3").sum(dim=["TIMESLICE", "FUEL"]).item()
+    assert np.round(r1_to_r2, 10) == 5
+    assert np.round(r1_to_r3, 10) == 5

--- a/tz/osemosys/model/constraints/trade.py
+++ b/tz/osemosys/model/constraints/trade.py
@@ -76,27 +76,32 @@ def add_trade_constraints(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpress
         m.add_constraints(con, name="TC4_TradeConstraint", mask=mask)
 
         # Activity constraints
-        # absolute annual activity constraints:
-        con = lex["NetTradeAnnual"] <= ds["TotalTradeAnnualActivityUpperLimit"] * ds["TradeRoute"]
+        con = lex["ExportAnnual"] <= ds["TotalTradeAnnualActivityUpperLimit"] * ds["TradeRoute"] * (
+            1 - ds["TradeLossBetweenRegions"]
+        )
         mask = mask_ & ds["TotalTradeAnnualActivityUpperLimit"].notnull()
         m.add_constraints(con, name="TradeConstraint_TotalTradeAnnualActivityUpperLimit", mask=mask)
-        con = lex["NetTradeAnnual"] >= ds["TotalTradeAnnualActivityLowerLimit"] * ds["TradeRoute"]
+        con = lex["ExportAnnual"] >= ds["TotalTradeAnnualActivityLowerLimit"] * ds["TradeRoute"] * (
+            1 - ds["TradeLossBetweenRegions"]
+        )
         mask = mask_ & ds["TotalTradeAnnualActivityLowerLimit"].notnull()
         m.add_constraints(con, name="TradeConstraint_TotalTradeAnnualActivityLowerLimit", mask=mask)
         # availability factor constraints:
         con = (
-            lex["NetTradeAnnual"]
+            lex["ExportAnnual"]
             <= lex["GrossTradeCapacity"]
             * ds["TradeRoute"]
+            * (1 - ds["TradeLossBetweenRegions"])
             * ds["AvailabilityFactorTrade"]
             * ds["TradeCapacityToActivityUnit"]
         )
         mask = mask_ & ds["AvailabilityFactorTrade"].notnull()
         m.add_constraints(con, name="TradeConstraint_AvailabilityFactor", mask=mask)
         con = (
-            lex["NetTradeAnnual"]
+            lex["ExportAnnual"]
             >= lex["GrossTradeCapacity"]
             * ds["TradeRoute"]
+            * (1 - ds["TradeLossBetweenRegions"])
             * ds["TotalAnnualMinCapacityFactorTrade"]
             * ds["TradeCapacityToActivityUnit"]
         )

--- a/tz/osemosys/model/linear_expressions/trade.py
+++ b/tz/osemosys/model/linear_expressions/trade.py
@@ -21,6 +21,7 @@ def add_lex_trade(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
         .fillna(0)
     )
     NetTradeAnnual = NetTrade.sum("TIMESLICE")
+    ExportAnnual = m["Export"].sum("TIMESLICE")
 
     # Discounting #
     DiscountFactorTrade = (1 + ds["DiscountRateTrade"]) ** (
@@ -100,6 +101,7 @@ def add_lex_trade(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
             "GrossTradeCapacity": GrossTradeCapacity,
             "NetTrade": NetTrade,
             "NetTradeAnnual": NetTradeAnnual,
+            "ExportAnnual": ExportAnnual,
             "SV1NumeratorTrade": SV1NumeratorTrade,
             "SV1DenominatorTrade": SV1DenominatorTrade,
             "SV2NumeratorTrade": SV2NumeratorTrade,

--- a/tz/osemosys/model/solution.py
+++ b/tz/osemosys/model/solution.py
@@ -38,6 +38,7 @@ SOLUTION_KEYS = [
     "NetTradeAnnual",
     "Import",
     "Export",
+    "ExportAnnual",
     "NewTradeCapacity",
     "GrossTradeCapacity",
     "SalvageValueTrade",


### PR DESCRIPTION
## Description

### Activity constraints use annual export

- **Activity constraints (`trade.py`):** Trade activity constraints (upper/lower annual limits, availability factor, and minimum annual capacity factor) now use **Export** (and **ExportAnnual** = `Export.sum("TIMESLICE")`) instead of NetTrade/NetTradeAnnual.

- **Tests:** A new 3-node trade test (`test_3_node_trade.py`) checks that export flows and minimum capacity-factor (utilisation) constraints behave correctly when one region exports to two others with different variable costs and min-flow requirements. It asserts on `model.solution["Export"]` (e.g. Export R1→R2 and R1→R3 both 5 for the solved year).

---

## Changes made per file

- **`tz/osemosys/model/linear_expressions/trade.py`**  
  Added `ExportAnnual = m["Export"].sum("TIMESLICE")` and passed it in the lex dict so activity constraints can use annual export per route.

- **`tz/osemosys/model/constraints/trade.py`**  
  Activity constraints (TotalTradeAnnualActivityUpperLimit, TotalTradeAnnualActivityLowerLimit, AvailabilityFactor, TotalAnnualMinCapacityFactorTrade) now use `lex["ExportAnnual"]` instead of `lex["NetTradeAnnual"]`. Upper/lower activity limits and availability/capacity-factor constraints are scaled by `(1 - ds["TradeLossBetweenRegions"])` where needed so they apply to export.

- **`tz/osemosys/model/solution.py`**  
  Added `"ExportAnnual"` to `SOLUTION_KEYS` so the solution dataset exposes annual export per route.

- **`tests/test_solve/test_3_node_trade.py`**  
  New test: 3-region setup (R1 exporter to R2 and R3) with asymmetric variable costs and `capacity_factor_annual_min=0.5` on both links. Asserts that `model.solution["Export"]` gives 5 on R1→R2 and 5 on R1→R3 for the solved year, verifying minimum utilisation and correct export split.