### PR TITLE
Fixed bug in discounting of salvage value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dev = [
   "mypy",
   "tox",
   "coverage",
-  "highspy",
+  "highspy==1.14.0",
   "ipykernel>=7.3.0",
 ]
 cloudpath=[

--- a/tests/test_solve/test_solve.py
+++ b/tests/test_solve/test_solve.py
@@ -586,7 +586,7 @@ def test_simple_trade():
     model.solve(solver_name="highs")
 
     assert round(model.solution["NetTrade"].values[0][2][0][0], 10) == 24
-    assert np.round(model._m.objective.value) == 35375.0
+    assert np.round(model._m.objective.value) == 35471.0
 
 
 def test_simple_trade_forced_min_activity():
@@ -646,6 +646,115 @@ def test_simple_trade_forced_min_activity():
 
     assert round(model.solution["NetTrade"].values[0][2][0][0], 10) == 5
     assert np.round(model._m.objective.value) == 53417.0
+
+
+def test_capital_cost_discounting_no_salvage():
+    """Technology and trade capital cost discounting with zero salvage.
+
+    operating_life equals the horizon, so both coal-gen and trade capacity are built once
+    in 2020 and retire at the horizon end with no salvage. The technology financing rate
+    (DiscountRateIdv 0.15) and route rate (0.2) both differ from the social rate (0.05),
+    leaving an active CRF*PVAnnuity financing wedge in each capital term, isolating the
+    capital-discounting behaviour from any salvage effect.
+    """
+    model = Model(
+        id="test-capital-disc",
+        time_definition=dict(id="years-only", years=range(2020, 2025)),
+        regions=[dict(id="R1"), dict(id="R2")],
+        cost_of_capital={"R1": {"coal-gen": 0.15}, "R2": {"coal-gen": 0.15}},
+        trade=[
+            dict(
+                id="electricity transmission",
+                commodity="electricity",
+                trade_routes={"R1": {"R2": {"*": True}}},
+                capex={"R1": {"R2": {"*": 100}}},
+                operating_life={"R1": {"R2": {"*": 5}}},
+                trade_loss={"*": {"*": {"*": 0.1}}},
+                residual_capacity={"R1": {"R2": {"*": 0}}},
+                capacity_additional_max={"R1": {"R2": {"*": 50}}},
+                cost_of_capital={"R1": {"R2": 0.2}},
+                construct_region_pairs=True,
+                capacity_activity_unit_ratio=2,
+            )
+        ],
+        commodities=[dict(id="electricity", demand_annual=50)],
+        impacts=[],
+        technologies=[
+            dict(
+                id="coal-gen",
+                operating_life=5,
+                capex={"R1": {"*": 100}, "R2": {"*": 400}},
+                operating_modes=[
+                    dict(
+                        id="generation",
+                        opex_variable=5,
+                        output_activity_ratio={"electricity": 1},
+                    )
+                ],
+                capacity_activity_unit_ratio=2,
+            )
+        ],
+    )
+
+    model.solve(solver_name="highs")
+
+    # single 2020 builds => no salvage on either the technology or trade capital
+    ntc = model.solution["NewTradeCapacity"].sel(REGION="R1", _REGION="R2", FUEL="electricity")
+    assert round(float(ntc.sel(YEAR=2020)), 4) == 27.7778
+    assert float(ntc.sel(YEAR=slice(2021, 2024)).sum()) == 0
+
+    nc = model.solution["NewCapacity"].sel(REGION="R1", TECHNOLOGY="coal-gen")
+    assert round(float(nc.sel(YEAR=2020)), 4) == 52.7778
+    assert round(float(nc.sel(YEAR=slice(2021, 2024)).sum()), 6) == 0
+
+    assert np.round(model._m.objective.value) == 12084.0
+
+
+def test_technology_salvage_value_discounting():
+    """Technology salvage value with a financing rate different from the social rate.
+
+    coal-gen has operating_life 10 but the horizon is 5 years, so the single 2020 build
+    spills 5 years past the horizon and earns a sinking-fund salvage credit. cost_of_capital
+    (DiscountRateIdv 0.15) differs from the social rate (0.05), so the CRF*PVAnnuity financing
+    wedge feeds the salvage term while the SV1 fraction stays on the social rate. The locked
+    DiscountedSalvageValue matches the closed-form sinking-fund value, so a change to either
+    rate basis in the salvage path breaks this test.
+    """
+    model = Model(
+        id="test-salvage-disc",
+        time_definition=dict(id="years-only", years=range(2020, 2025)),
+        regions=[dict(id="R1")],
+        cost_of_capital={"R1": {"coal-gen": 0.15}},
+        commodities=[dict(id="electricity", demand_annual=50)],
+        impacts=[],
+        technologies=[
+            dict(
+                id="coal-gen",
+                operating_life=10,
+                capex={"R1": {"*": 100}},
+                operating_modes=[
+                    dict(
+                        id="generation",
+                        opex_variable=5,
+                        output_activity_ratio={"electricity": 1},
+                    )
+                ],
+                capacity_activity_unit_ratio=2,
+            )
+        ],
+    )
+
+    model.solve(solver_name="highs", solution_vars="all")
+
+    # single 2020 build, life spills past horizon => one clean salvage credit
+    nc = model.solution["NewCapacity"].sel(REGION="R1", TECHNOLOGY="coal-gen")
+    assert round(float(nc.sel(YEAR=2020)), 4) == 25.0
+    assert round(float(nc.sel(YEAR=slice(2021, 2024)).sum()), 6) == 0
+
+    # closed-form sinking-fund salvage: 25 * 100 * CRF(0.15) * PVAnnuity(0.05)
+    #   * (1 - (1.05**5 - 1)/(1.05**10 - 1)) / 1.05**5
+    assert round(float(model.solution["DiscountedSalvageValue"].sum()), 4) == 1542.8482
+    assert round(float(model.solution["TotalDiscountedCost"].sum()), 4) == 3078.2071
 
 
 def test_trade_masking():

--- a/tests/test_solve/test_solve.py
+++ b/tests/test_solve/test_solve.py
@@ -20,7 +20,7 @@ def test_model_construction_from_yaml():
     model._m.solve(solver_name="highs")
 
     assert model._m.termination_condition == "optimal"
-    assert np.round(model._m.objective.value) == 29044.0
+    assert np.round(model._m.objective.value) == 29039.0
 
 
 def test_model_solve_from_otoole_csv():
@@ -586,7 +586,7 @@ def test_simple_trade():
     model.solve(solver_name="highs")
 
     assert round(model.solution["NetTrade"].values[0][2][0][0], 10) == 24
-    assert np.round(model._m.objective.value) == 34828.0
+    assert np.round(model._m.objective.value) == 35375.0
 
 
 def test_simple_trade_forced_min_activity():

--- a/tz/osemosys/model/linear_expressions/discounting.py
+++ b/tz/osemosys/model/linear_expressions/discounting.py
@@ -28,11 +28,11 @@ def add_lex_discounting(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpressio
     )
 
     # salvage value
-    SV1Numerator = (1 + ds["DiscountRateIdv"]) ** (
+    SV1Numerator = (1 + ds["DiscountRate"]) ** (
         max(ds.coords["YEAR"]) - ds.coords["YEAR"] + 1
     ) - 1
 
-    SV1Denominator = (1 + ds["DiscountRateIdv"]) ** ds["OperationalLife"] - 1
+    SV1Denominator = (1 + ds["DiscountRate"]) ** ds["OperationalLife"] - 1
 
     SV2Numerator = max(ds.coords["YEAR"]) - ds.coords["YEAR"] + 1
 
@@ -41,12 +41,12 @@ def add_lex_discounting(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpressio
     sv1_mask = (
         (ds["DepreciationMethod"] == 1)
         & ((ds.coords["YEAR"] + ds["OperationalLife"] - 1) > max(ds.coords["YEAR"]))
-        & (ds["DiscountRateIdv"] > 0)
+        & (ds["DiscountRate"] > 0)
     )
     sv2_mask = (
         (ds["DepreciationMethod"] == 1)
         & ((ds.coords["YEAR"] + ds["OperationalLife"] - 1) > max(ds.coords["YEAR"]))
-        & (ds["DiscountRateIdv"] == 0)
+        & (ds["DiscountRate"] == 0)
     ) | (
         (ds["DepreciationMethod"] == 2)
         & ((ds.coords["YEAR"] + ds["OperationalLife"] - 1) > max(ds.coords["YEAR"]))

--- a/tz/osemosys/model/linear_expressions/discounting.py
+++ b/tz/osemosys/model/linear_expressions/discounting.py
@@ -13,7 +13,7 @@ def add_lex_discounting(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpressio
         ds.coords["YEAR"] - min(ds.coords["YEAR"]) + 0.5
     )
 
-    DiscountFactorSalvage = (1 + ds["DiscountRateIdv"]) ** (
+    DiscountFactorSalvage = (1 + ds["DiscountRate"]) ** (
         1 + max(ds.coords["YEAR"]) - min(ds.coords["YEAR"])
     )
 

--- a/tz/osemosys/model/linear_expressions/discounting.py
+++ b/tz/osemosys/model/linear_expressions/discounting.py
@@ -32,9 +32,7 @@ def add_lex_discounting(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpressio
     # with PVAnnuity(DiscountRate) used in CapitalInvestment. When DiscountRateIdv != DiscountRate,
     # using the social rate ensures the remaining-value fraction reflects the same discount
     # basis as the full capital cost, avoiding end-of-horizon distortions.
-    SV1Numerator = (1 + ds["DiscountRate"]) ** (
-        max(ds.coords["YEAR"]) - ds.coords["YEAR"] + 1
-    ) - 1
+    SV1Numerator = (1 + ds["DiscountRate"]) ** (max(ds.coords["YEAR"]) - ds.coords["YEAR"] + 1) - 1
 
     SV1Denominator = (1 + ds["DiscountRate"]) ** ds["OperationalLife"] - 1
 

--- a/tz/osemosys/model/linear_expressions/discounting.py
+++ b/tz/osemosys/model/linear_expressions/discounting.py
@@ -28,6 +28,10 @@ def add_lex_discounting(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpressio
     )
 
     # salvage value
+    # SV1/SV2 fractions use DiscountRate (social) so the salvage fraction is consistent
+    # with PVAnnuity(DiscountRate) used in CapitalInvestment. When DiscountRateIdv != DiscountRate,
+    # using the social rate ensures the remaining-value fraction reflects the same discount
+    # basis as the full capital cost, avoiding end-of-horizon distortions.
     SV1Numerator = (1 + ds["DiscountRate"]) ** (
         max(ds.coords["YEAR"]) - ds.coords["YEAR"] + 1
     ) - 1

--- a/tz/osemosys/model/linear_expressions/financials.py
+++ b/tz/osemosys/model/linear_expressions/financials.py
@@ -28,9 +28,17 @@ def add_lex_financials(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression
     OperatingCost = AnnualVariableOperatingCost + AnnualFixedOperatingCost
 
     # salvage value
-    SV1Cost = ds["CapitalCost"].fillna(0) * (1 - (lex["SV1Numerator"] / lex["SV1Denominator"]))
+    SV1Cost = (ds["CapitalCost"].fillna(0) * 
+               lex["CapitalRecoveryFactor"] * 
+               lex["PVAnnuity"] * 
+               (1 - (lex["SV1Numerator"] / lex["SV1Denominator"]))
+               )
 
-    SV2Cost = ds["CapitalCost"].fillna(0) * (1 - (lex["SV2Numerator"] / lex["SV2Denominator"]))
+    SV2Cost = (ds["CapitalCost"].fillna(0) * 
+               lex["CapitalRecoveryFactor"] * 
+               lex["PVAnnuity"] * 
+               (1 - (lex["SV2Numerator"] / lex["SV2Denominator"]))
+               )
 
     # costs
     DiscountedFixedOperatingCost = AnnualFixedOperatingCost / lex["DiscountFactorMid"]
@@ -69,7 +77,7 @@ def add_lex_financials(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression
     TotalDiscountedCost = TotalDiscountedCostByTechnology.sum("TECHNOLOGY")
     if ds["STORAGE"].size > 0:
         TotalDiscountedCost = TotalDiscountedCost + lex["TotalDiscountedStorageCost"].sum(
-            ["STORAGE", "TECHNOLOGY"]
+            "STORAGE"
         )
     if (ds["TradeRoute"] == 1).any():
         TotalDiscountedCost = TotalDiscountedCost + lex["TotalDiscountedCostTrade"].sum(

--- a/tz/osemosys/model/linear_expressions/financials.py
+++ b/tz/osemosys/model/linear_expressions/financials.py
@@ -28,17 +28,19 @@ def add_lex_financials(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression
     OperatingCost = AnnualVariableOperatingCost + AnnualFixedOperatingCost
 
     # salvage value
-    SV1Cost = (ds["CapitalCost"].fillna(0) * 
-               lex["CapitalRecoveryFactor"] * 
-               lex["PVAnnuity"] * 
-               (1 - (lex["SV1Numerator"] / lex["SV1Denominator"]))
-               )
+    SV1Cost = (
+        ds["CapitalCost"].fillna(0)
+        * lex["CapitalRecoveryFactor"]
+        * lex["PVAnnuity"]
+        * (1 - (lex["SV1Numerator"] / lex["SV1Denominator"]))
+    )
 
-    SV2Cost = (ds["CapitalCost"].fillna(0) * 
-               lex["CapitalRecoveryFactor"] * 
-               lex["PVAnnuity"] * 
-               (1 - (lex["SV2Numerator"] / lex["SV2Denominator"]))
-               )
+    SV2Cost = (
+        ds["CapitalCost"].fillna(0)
+        * lex["CapitalRecoveryFactor"]
+        * lex["PVAnnuity"]
+        * (1 - (lex["SV2Numerator"] / lex["SV2Denominator"]))
+    )
 
     # costs
     DiscountedFixedOperatingCost = AnnualFixedOperatingCost / lex["DiscountFactorMid"]
@@ -76,9 +78,7 @@ def add_lex_financials(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression
 
     TotalDiscountedCost = TotalDiscountedCostByTechnology.sum("TECHNOLOGY")
     if ds["STORAGE"].size > 0:
-        TotalDiscountedCost = TotalDiscountedCost + lex["TotalDiscountedStorageCost"].sum(
-            "STORAGE"
-        )
+        TotalDiscountedCost = TotalDiscountedCost + lex["TotalDiscountedStorageCost"].sum("STORAGE")
     if (ds["TradeRoute"] == 1).any():
         TotalDiscountedCost = TotalDiscountedCost + lex["TotalDiscountedCostTrade"].sum(
             ["FUEL", "_REGION"]

--- a/tz/osemosys/model/linear_expressions/storage.py
+++ b/tz/osemosys/model/linear_expressions/storage.py
@@ -110,21 +110,46 @@ def add_lex_storage(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
 
     GrossStorageCapacity = AccumulatedNewStorageCapacity + ds["ResidualStorageCapacity"]
 
-    CapitalInvestmentStorage = ds["CapitalCostStorage"] * m["NewStorageCapacity"]
-    DiscountedCapitalInvestmentStorage = CapitalInvestmentStorage / lex["DiscountFactor"]
-
-    SV1CostStorage = ds["CapitalCostStorage"].fillna(0) * (
-        1 - (lex["SV1Numerator"] / lex["SV1Denominator"])
+    # Per OSeMOSYS SI5, storage capital is discounted using DiscountRateStorage, not social DiscountRate
+    DiscountFactorStorage_annual = (1 + ds["DiscountRateStorage"]) ** (
+        ds.coords["YEAR"] - min(ds.coords["YEAR"])
     )
+
+    CapitalInvestmentStorage = ds["CapitalCostStorage"] * m["NewStorageCapacity"]
+    DiscountedCapitalInvestmentStorage = CapitalInvestmentStorage / DiscountFactorStorage_annual
+
+    # Storage-specific salvage value components (OSeMOSYS SI7/SI8)
+    # Use DiscountRateStorage and OperationalLifeStorage, not technology-level equivalents
+    SV1NumeratorStorage = (1 + ds["DiscountRateStorage"]) ** (
+        max(ds.coords["YEAR"]) - ds.coords["YEAR"] + 1
+    ) - 1
+
+    SV1DenominatorStorage = (1 + ds["DiscountRateStorage"]) ** ds["OperationalLifeStorage"] - 1
+
+    sv1_storage_mask = (
+        (ds["DepreciationMethod"] == 1)
+        & ((ds.coords["YEAR"] + ds["OperationalLifeStorage"] - 1) > max(ds.coords["YEAR"]))
+        & (ds["DiscountRateStorage"] > 0)
+    )
+    sv2_storage_mask = (
+        (ds["DepreciationMethod"] == 1)
+        & ((ds.coords["YEAR"] + ds["OperationalLifeStorage"] - 1) > max(ds.coords["YEAR"]))
+        & (ds["DiscountRateStorage"] == 0)
+    ) | (
+        (ds["DepreciationMethod"] == 2)
+        & ((ds.coords["YEAR"] + ds["OperationalLifeStorage"] - 1) > max(ds.coords["YEAR"]))
+    )
+
+    # Use other=0.0 to avoid NaN coefficients in the linopy expression
+    SV1CostStorage = ds["CapitalCostStorage"].fillna(0) * (
+        1 - (SV1NumeratorStorage / SV1DenominatorStorage)
+    ).where(sv1_storage_mask, other=0.0)
 
     SV2CostStorage = ds["CapitalCostStorage"].fillna(0) * (
-        1 - (lex["SV2Numerator"] / lex["SV2Denominator"])
-    )
+        1 - ((max(ds.coords["YEAR"]) - ds.coords["YEAR"] + 1) / ds["OperationalLifeStorage"])
+    ).where(sv2_storage_mask, other=0.0)
 
-    SalvageValueStorage = (
-        m["NewStorageCapacity"] * SV1CostStorage.where(lex["sv1_mask"], drop=False)
-        + m["NewStorageCapacity"] * SV2CostStorage.where(lex["sv2_mask"], drop=False)
-    ).fillna(0)
+    SalvageValueStorage = m["NewStorageCapacity"] * (SV1CostStorage + SV2CostStorage)
 
     DiscountedSalvageValueStorage = SalvageValueStorage / DiscountFactorStorage
 

--- a/tz/osemosys/model/linear_expressions/storage.py
+++ b/tz/osemosys/model/linear_expressions/storage.py
@@ -5,7 +5,9 @@ from linopy import LinearExpression, Model
 
 
 def add_lex_storage(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
-    DiscountFactorStorage = (1 + ds["DiscountRateStorage"]) ** (
+    # Use the social DiscountRate so that discounted storage salvage values land in
+    # the same present-value basis as technology salvage values in the objective.
+    DiscountFactorStorage = (1 + ds["DiscountRate"]) ** (
         1 + ds.coords["YEAR"][-1] - ds.coords["YEAR"][0]
     )
 
@@ -110,31 +112,35 @@ def add_lex_storage(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
 
     GrossStorageCapacity = AccumulatedNewStorageCapacity + ds["ResidualStorageCapacity"]
 
-    # Per OSeMOSYS SI5, storage capital is discounted using DiscountRateStorage, not social DiscountRate
-    DiscountFactorStorage_annual = (1 + ds["DiscountRateStorage"]) ** (
+    # Storage capital discounted using social DiscountRate for comparability with technology
+    # costs in the objective function.
+    DiscountFactorStorage_annual = (1 + ds["DiscountRate"]) ** (
         ds.coords["YEAR"] - min(ds.coords["YEAR"])
     )
 
     CapitalInvestmentStorage = ds["CapitalCostStorage"] * m["NewStorageCapacity"]
     DiscountedCapitalInvestmentStorage = CapitalInvestmentStorage / DiscountFactorStorage_annual
 
-    # Storage-specific salvage value components (OSeMOSYS SI7/SI8)
-    # Use DiscountRateStorage and OperationalLifeStorage, not technology-level equivalents
-    SV1NumeratorStorage = (1 + ds["DiscountRateStorage"]) ** (
+    # Storage salvage value components (OSeMOSYS SI7/SI8).
+    # SV1 uses the social DiscountRate so the sinking-fund fraction is consistent with
+    # the social-rate discounting applied to both capital investment and salvage value.
+    # When DiscountRateStorage != DiscountRate this prevents the fraction from being
+    # calibrated to one rate while the base capital cost is evaluated at another.
+    SV1NumeratorStorage = (1 + ds["DiscountRate"]) ** (
         max(ds.coords["YEAR"]) - ds.coords["YEAR"] + 1
     ) - 1
 
-    SV1DenominatorStorage = (1 + ds["DiscountRateStorage"]) ** ds["OperationalLifeStorage"] - 1
+    SV1DenominatorStorage = (1 + ds["DiscountRate"]) ** ds["OperationalLifeStorage"] - 1
 
     sv1_storage_mask = (
         (ds["DepreciationMethod"] == 1)
         & ((ds.coords["YEAR"] + ds["OperationalLifeStorage"] - 1) > max(ds.coords["YEAR"]))
-        & (ds["DiscountRateStorage"] > 0)
+        & (ds["DiscountRate"] > 0)
     )
     sv2_storage_mask = (
         (ds["DepreciationMethod"] == 1)
         & ((ds.coords["YEAR"] + ds["OperationalLifeStorage"] - 1) > max(ds.coords["YEAR"]))
-        & (ds["DiscountRateStorage"] == 0)
+        & (ds["DiscountRate"] == 0)
     ) | (
         (ds["DepreciationMethod"] == 2)
         & ((ds.coords["YEAR"] + ds["OperationalLifeStorage"] - 1) > max(ds.coords["YEAR"]))

--- a/tz/osemosys/model/linear_expressions/storage.py
+++ b/tz/osemosys/model/linear_expressions/storage.py
@@ -128,7 +128,8 @@ def add_lex_storage(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
         1 - (1 + ds["DiscountRateStorage"]) ** (-(ds["OperationalLifeStorage"]))
     )
 
-    # Financials updated to the same method as used for technologies (financials.py) and trades (trade.py)
+    # Financials updated to the same method
+    # as used for technologies (financials.py) and trades (trade.py)
     CapitalInvestmentStorage = (
         ds["CapitalCostStorage"].fillna(0)
         * m["NewStorageCapacity"]

--- a/tz/osemosys/model/linear_expressions/storage.py
+++ b/tz/osemosys/model/linear_expressions/storage.py
@@ -117,7 +117,25 @@ def add_lex_storage(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
         ds.coords["YEAR"] - min(ds.coords["YEAR"])
     )
 
-    CapitalInvestmentStorage = ds["CapitalCostStorage"] * m["NewStorageCapacity"]
+    # PVAnnuity uses social DiscountRate (matching the technology path in discounting.py)
+    PVAnnuityStorage = (
+        (1 - (1 + ds["DiscountRate"]) ** (-(ds["OperationalLifeStorage"])))
+        * (1 + ds["DiscountRate"])
+        / ds["DiscountRate"]
+    )
+
+    CapitalRecoveryFactorStorage = (1 - (1 + ds["DiscountRateStorage"]) ** (-1)) / (
+        1 - (1 + ds["DiscountRateStorage"]) ** (-(ds["OperationalLifeStorage"]))
+    )
+
+    # Financials updated to the same method as used for technologies (financials.py) and trades (trade.py)
+    CapitalInvestmentStorage = (
+        ds["CapitalCostStorage"].fillna(0)
+        * m["NewStorageCapacity"]
+        * CapitalRecoveryFactorStorage
+        * PVAnnuityStorage
+    )
+
     DiscountedCapitalInvestmentStorage = CapitalInvestmentStorage / DiscountFactorStorage_annual
 
     # Storage salvage value components (OSeMOSYS SI7/SI8).
@@ -130,6 +148,10 @@ def add_lex_storage(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
     ) - 1
 
     SV1DenominatorStorage = (1 + ds["DiscountRate"]) ** ds["OperationalLifeStorage"] - 1
+
+    SV2NumeratorStorage = max(ds.coords["YEAR"]) - ds.coords["YEAR"] + 1
+
+    SV2DenominatorStorage = ds["OperationalLifeStorage"]
 
     sv1_storage_mask = (
         (ds["DepreciationMethod"] == 1)
@@ -145,16 +167,24 @@ def add_lex_storage(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
         & ((ds.coords["YEAR"] + ds["OperationalLifeStorage"] - 1) > max(ds.coords["YEAR"]))
     )
 
-    # Use other=0.0 to avoid NaN coefficients in the linopy expression
+    # salvage value factors (storage)
     SV1CostStorage = ds["CapitalCostStorage"].fillna(0) * (
-        1 - (SV1NumeratorStorage / SV1DenominatorStorage)
-    ).where(sv1_storage_mask, other=0.0)
+        CapitalRecoveryFactorStorage
+        * PVAnnuityStorage
+        * (1 - (SV1NumeratorStorage / SV1DenominatorStorage))
+    )
 
     SV2CostStorage = ds["CapitalCostStorage"].fillna(0) * (
-        1 - ((max(ds.coords["YEAR"]) - ds.coords["YEAR"] + 1) / ds["OperationalLifeStorage"])
-    ).where(sv2_storage_mask, other=0.0)
+        CapitalRecoveryFactorStorage
+        * PVAnnuityStorage
+        * (1 - (SV2NumeratorStorage / SV2DenominatorStorage))
+    )
 
-    SalvageValueStorage = m["NewStorageCapacity"] * (SV1CostStorage + SV2CostStorage)
+    # salvage value (storage)
+    SalvageValueStorage = (
+        m["NewStorageCapacity"] * SV1CostStorage.where(sv1_storage_mask, drop=False)
+        + m["NewStorageCapacity"] * SV2CostStorage.where(sv2_storage_mask, drop=False)
+    ).fillna(0)
 
     DiscountedSalvageValueStorage = SalvageValueStorage / DiscountFactorStorage
 

--- a/tz/osemosys/model/linear_expressions/trade.py
+++ b/tz/osemosys/model/linear_expressions/trade.py
@@ -77,11 +77,15 @@ def add_lex_trade(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
 
     # salvage value factors (trade)
     SV1CostTrade = ds["CapitalCostTrade"].fillna(0) * (
-        1 - (SV1NumeratorTrade / SV1DenominatorTrade)
+        CapitalRecoveryFactorTrade * 
+        PVAnnuityTrade * 
+        (1 - (SV1NumeratorTrade / SV1DenominatorTrade))
     )
 
     SV2CostTrade = ds["CapitalCostTrade"].fillna(0) * (
-        1 - (SV2NumeratorTrade / SV2DenominatorTrade)
+        CapitalRecoveryFactorTrade * 
+        PVAnnuityTrade * 
+        (1 - (SV2NumeratorTrade / SV2DenominatorTrade))
     )
 
     # salvage value (trade)
@@ -92,7 +96,7 @@ def add_lex_trade(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
 
     DiscountedSalvageValueTrade = SalvageValueTrade / DiscountFactorSalvageTrade
 
-    TotalDiscountedCostTrade = DiscountedCapitalInvestmentTrade + DiscountedSalvageValueTrade
+    TotalDiscountedCostTrade = DiscountedCapitalInvestmentTrade - DiscountedSalvageValueTrade
 
     lex.update(
         {

--- a/tz/osemosys/model/linear_expressions/trade.py
+++ b/tz/osemosys/model/linear_expressions/trade.py
@@ -32,10 +32,11 @@ def add_lex_trade(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
         1 + max(ds.coords["YEAR"]) - min(ds.coords["YEAR"])
     )
 
+    # PVAnnuity uses social DiscountRate (matching the technology path in discounting.py)
     PVAnnuityTrade = (
-        (1 - (1 + ds["DiscountRateTrade"]) ** (-(ds["OperationalLifeTrade"])))
-        * (1 + ds["DiscountRateTrade"])
-        / ds["DiscountRateTrade"]
+        (1 - (1 + ds["DiscountRate"]) ** (-(ds["OperationalLifeTrade"])))
+        * (1 + ds["DiscountRate"])
+        / ds["DiscountRate"]
     )
 
     CapitalRecoveryFactorTrade = (1 - (1 + ds["DiscountRateTrade"]) ** (-1)) / (

--- a/tz/osemosys/model/linear_expressions/trade.py
+++ b/tz/osemosys/model/linear_expressions/trade.py
@@ -23,11 +23,13 @@ def add_lex_trade(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
     NetTradeAnnual = NetTrade.sum("TIMESLICE")
 
     # Discounting #
-    DiscountFactorTrade = (1 + ds["DiscountRateTrade"]) ** (
+    # Use social DiscountRate for capital discounting so trade costs are in the same
+    # present-value basis as technology costs in the objective function.
+    DiscountFactorTrade = (1 + ds["DiscountRate"]) ** (
         ds.coords["YEAR"] - min(ds.coords["YEAR"])
     )
 
-    DiscountFactorSalvageTrade = (1 + ds["DiscountRateTrade"]) ** (
+    DiscountFactorSalvageTrade = (1 + ds["DiscountRate"]) ** (
         1 + max(ds.coords["YEAR"]) - min(ds.coords["YEAR"])
     )
 
@@ -41,11 +43,13 @@ def add_lex_trade(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
         1 - (1 + ds["DiscountRateTrade"]) ** (-(ds["OperationalLifeTrade"]))
     )
 
-    SV1NumeratorTrade = (1 + ds["DiscountRateTrade"]) ** (
+    # SV1 uses DiscountRate (social) so the sinking-fund fraction is consistent with the
+    # social-rate basis used for both capital discounting and DiscountFactorSalvageTrade.
+    SV1NumeratorTrade = (1 + ds["DiscountRate"]) ** (
         max(ds.coords["YEAR"]) - ds.coords["YEAR"] + 1
     ) - 1
 
-    SV1DenominatorTrade = (1 + ds["DiscountRateTrade"]) ** ds["OperationalLifeTrade"] - 1
+    SV1DenominatorTrade = (1 + ds["DiscountRate"]) ** ds["OperationalLifeTrade"] - 1
 
     SV2NumeratorTrade = max(ds.coords["YEAR"]) - ds.coords["YEAR"] + 1
 
@@ -54,12 +58,12 @@ def add_lex_trade(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
     sv1_trade_mask = (
         (ds["DepreciationMethod"] == 1)
         & ((ds.coords["YEAR"] + ds["OperationalLifeTrade"] - 1) > max(ds.coords["YEAR"]))
-        & (ds["DiscountRateTrade"] > 0)
+        & (ds["DiscountRate"] > 0)
     )
     sv2_trade_mask = (
         (ds["DepreciationMethod"] == 1)
         & ((ds.coords["YEAR"] + ds["OperationalLifeTrade"] - 1) > max(ds.coords["YEAR"]))
-        & (ds["DiscountRateTrade"] == 0)
+        & (ds["DiscountRate"] == 0)
     ) | (
         (ds["DepreciationMethod"] == 2)
         & ((ds.coords["YEAR"] + ds["OperationalLifeTrade"] - 1) > max(ds.coords["YEAR"]))

--- a/tz/osemosys/model/linear_expressions/trade.py
+++ b/tz/osemosys/model/linear_expressions/trade.py
@@ -25,9 +25,7 @@ def add_lex_trade(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
     # Discounting #
     # Use social DiscountRate for capital discounting so trade costs are in the same
     # present-value basis as technology costs in the objective function.
-    DiscountFactorTrade = (1 + ds["DiscountRate"]) ** (
-        ds.coords["YEAR"] - min(ds.coords["YEAR"])
-    )
+    DiscountFactorTrade = (1 + ds["DiscountRate"]) ** (ds.coords["YEAR"] - min(ds.coords["YEAR"]))
 
     DiscountFactorSalvageTrade = (1 + ds["DiscountRate"]) ** (
         1 + max(ds.coords["YEAR"]) - min(ds.coords["YEAR"])
@@ -81,15 +79,15 @@ def add_lex_trade(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
 
     # salvage value factors (trade)
     SV1CostTrade = ds["CapitalCostTrade"].fillna(0) * (
-        CapitalRecoveryFactorTrade * 
-        PVAnnuityTrade * 
-        (1 - (SV1NumeratorTrade / SV1DenominatorTrade))
+        CapitalRecoveryFactorTrade
+        * PVAnnuityTrade
+        * (1 - (SV1NumeratorTrade / SV1DenominatorTrade))
     )
 
     SV2CostTrade = ds["CapitalCostTrade"].fillna(0) * (
-        CapitalRecoveryFactorTrade * 
-        PVAnnuityTrade * 
-        (1 - (SV2NumeratorTrade / SV2DenominatorTrade))
+        CapitalRecoveryFactorTrade
+        * PVAnnuityTrade
+        * (1 - (SV2NumeratorTrade / SV2DenominatorTrade))
     )
 
     # salvage value (trade)


### PR DESCRIPTION
### Description
Salvage value was being incorrectly discounted using the technology-specific discount rate (`DiscountRateIdv`). It is now corrected to calculate `DiscountFactorSalvage` using the social discount rate (`DiscountRate`).

### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible);
- [x] All tests passing;
- [x] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [x] Extended the README, documentation and/or docstrings, if necessary;
