### PR TITLE
Refactor StorageGrossCapacitySufficiency constraint

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up Python 3.11
         uses: actions/setup-python@v3
         with:
@@ -38,6 +40,10 @@ jobs:
       image: ghcr.io/transition-zero/tz-highs/highs-python:latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Mark workspace as safe for git
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: Install jq
       uses: dcarbone/install-jq-action@v2.1.0
     - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,10 @@ classifiers = [  # Optional
 
 dependencies = [
   "pandas<3",
-  "pydantic>2",
+  "pydantic>2,<2.13",
   "pydantic-settings",
   "h5py",
-  "xarray",
+  "xarray<2026",
   "orjson",
   "linopy==0.5.5",
   "h5netcdf",
@@ -57,6 +57,7 @@ dev = [
   "tox",
   "coverage",
   "highspy",
+  "ipykernel>=7.3.0",
 ]
 cloudpath=[
   "cloudpathlib[all]",
@@ -90,4 +91,5 @@ find = { include = ["tz.*"] }
 # https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
 requires = ["setuptools>=43.0.0","setuptools_scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
+
 [tool.setuptools_scm]

--- a/tests/test_solve/test_solve.py
+++ b/tests/test_solve/test_solve.py
@@ -227,7 +227,7 @@ def test_simple_storage():
     net = model.solution.NetCharge.stack(YRTS=["YEAR", "TIMESLICE"])
     level = model.solution.StorageLevel.stack(YRTS=["YEAR", "TIMESLICE"])
     xr.testing.assert_allclose(level, net.cumsum("YRTS").rename("StorageLevel"))
-    
+
     # test storage level bounds
     assert (model.solution.StorageLevel >= -1e-6).all()
     assert (model.solution.StorageLevel <= model.solution.GrossStorageCapacity + 1e-6).all()

--- a/tests/test_solve/test_solve.py
+++ b/tests/test_solve/test_solve.py
@@ -223,6 +223,14 @@ def test_simple_storage():
         )
         == 0
     )
+    # test storage level recursion
+    net = model.solution.NetCharge.stack(YRTS=["YEAR", "TIMESLICE"])
+    level = model.solution.StorageLevel.stack(YRTS=["YEAR", "TIMESLICE"])
+    xr.testing.assert_allclose(level, net.cumsum("YRTS").rename("StorageLevel"))
+    
+    # test storage level bounds
+    assert (model.solution.StorageLevel >= -1e-6).all()
+    assert (model.solution.StorageLevel <= model.solution.GrossStorageCapacity + 1e-6).all()
 
 
 def test_simple_storage_seasonal_balancing():

--- a/tz/osemosys/model/constraints/storage.py
+++ b/tz/osemosys/model/constraints/storage.py
@@ -258,10 +258,11 @@ def add_storage_constraints(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpre
         # storage level may not exceed gross capacity
         # refactor previous dense cumsum constraint to sparse recursion constraint
 
-        # stack lex["StorageLevel"] and lex["NetCharge"] to be used in constraints
+        # stack StorageLevel and NetCharge to be used in constraints
         level = m["StorageLevel"].stack(YRTS=["YEAR", "TIMESLICE"])
         net = lex["NetCharge"].stack(YRTS=["YEAR", "TIMESLICE"])
-
+        level, net = xr.align(level, net, join="left")
+        net = net.fillna(0)
         # mask to filter out first timeslice
         not_first = xr.DataArray(
             np.arange(level.indexes["YRTS"].size) >= 1,

--- a/tz/osemosys/model/constraints/storage.py
+++ b/tz/osemosys/model/constraints/storage.py
@@ -1,5 +1,6 @@
 from typing import Dict
 
+import numpy as np
 import xarray as xr
 from linopy import LinearExpression, Model
 
@@ -255,16 +256,42 @@ def add_storage_constraints(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpre
     """
     if ds["STORAGE"].size > 0:
         # storage level may not exceed gross capacity
-        con = lex["StorageLevel"] <= lex["GrossStorageCapacity"].expand_dims(
-            {"TIMESLICE": ds["TIMESLICE"]}
-        ).stack(YRTS=["YEAR", "TIMESLICE"])
-        m.add_constraints(con, name="StorageGrossCapacitySufficiency")
+        # refactor previous dense cumsum constraint to sparse recursion constraint
+
+        # stack lex["StorageLevel"] and lex["NetCharge"] to be used in constraints
+        level = m["StorageLevel"].stack(YRTS=["YEAR", "TIMESLICE"])
+        net = lex["NetCharge"].stack(YRTS=["YEAR", "TIMESLICE"])
+
+        # mask to filter out first timeslice
+        not_first = xr.DataArray(
+            np.arange(level.indexes["YRTS"].size) >= 1,
+            dims="YRTS",
+            coords={"YRTS": level.coords["YRTS"]},
+        )
+
+        # add constraints for sparse recursion
+        m.add_constraints(
+            level - level.shift(YRTS=1) == net, name="StorageLevelRecursion", mask=not_first
+        )
+
+        # add constraints for initial storage level
+        m.add_constraints(
+            level.isel(YRTS=0) == net.isel(YRTS=0) + ds.get("StorageLevelStart", 0.0),
+            name="StorageLevelStart",
+        )
+
+        # add constraints for gross storage capacity sufficiency
+        m.add_constraints(
+            lex["StorageLevel"]
+            <= lex["GrossStorageCapacity"].expand_dims({"TIMESLICE": ds["TIMESLICE"]}),
+            name="StorageGrossCapacitySufficiency",
+        )
 
         # storage level may not be less than minimum charge
         if "MinStorageCharge" in ds.data_vars:
-            con = lex["StorageLevel"].fillna(0) >= ds["MinStorageCharge"].expand_dims(
+            con = lex["StorageLevel"] >= ds["MinStorageCharge"].expand_dims(
                 {"TIMESLICE": ds["TIMESLICE"]}
-            ).stack(YRTS=["YEAR", "TIMESLICE"])
+            )
             m.add_constraints(con, name="StorageMinimumCharge")
 
         # storage charge rate may not exceed max charge rate

--- a/tz/osemosys/model/constraints/storage.py
+++ b/tz/osemosys/model/constraints/storage.py
@@ -261,7 +261,7 @@ def add_storage_constraints(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpre
         # stack StorageLevel and NetCharge to be used in constraints
         level = m["StorageLevel"].stack(YRTS=["YEAR", "TIMESLICE"])
         net = lex["NetCharge"].stack(YRTS=["YEAR", "TIMESLICE"])
-        
+
         # mask to filter out first timeslice
         not_first = xr.DataArray(
             np.arange(level.indexes["YRTS"].size) >= 1,

--- a/tz/osemosys/model/constraints/storage.py
+++ b/tz/osemosys/model/constraints/storage.py
@@ -261,8 +261,7 @@ def add_storage_constraints(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpre
         # stack StorageLevel and NetCharge to be used in constraints
         level = m["StorageLevel"].stack(YRTS=["YEAR", "TIMESLICE"])
         net = lex["NetCharge"].stack(YRTS=["YEAR", "TIMESLICE"])
-        level, net = xr.align(level, net, join="left")
-        net = net.fillna(0)
+        
         # mask to filter out first timeslice
         not_first = xr.DataArray(
             np.arange(level.indexes["YRTS"].size) >= 1,

--- a/tz/osemosys/model/linear_expressions/storage.py
+++ b/tz/osemosys/model/linear_expressions/storage.py
@@ -95,9 +95,8 @@ def add_lex_storage(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
 
     NetCharge = ds["YearSplit"] * (RateOfStorageCharge - RateOfStorageDischarge)
 
-    NetChargeReshape = NetCharge.stack(YRTS=["YEAR", "TIMESLICE"])
-
-    StorageLevel = NetChargeReshape.cumsum("YRTS") + ds.get("StorageLevelStart", 0.0)
+    # Explicit storage level (state of charge) per timeslice
+    StorageLevel = m["StorageLevel"]
 
     NewStorageCapacity = m["NewStorageCapacity"].rename(YEAR="BUILDYEAR")
 

--- a/tz/osemosys/model/solution.py
+++ b/tz/osemosys/model/solution.py
@@ -112,7 +112,8 @@ def build_solution(
             )
         )
 
-    # also merge on StorageLevel after unstacking
+    # StorageLevel is now a first-class decision variable (see add_storage_variables), so it
+    # already arrives in m.solution.
     solution_base = m.solution.merge(
         xr.Dataset(
             {
@@ -122,11 +123,6 @@ def build_solution(
             }
         )
     ).merge(duals)
-
-    if "StorageLevel" in lex:
-        solution_base = solution_base.merge(
-            lex["StorageLevel"].solution.unstack("YRTS").rename("StorageLevel")
-        )
 
     if solution_vars is None:
         return solution_base[sorted(set(SOLUTION_KEYS) & set(solution_base.data_vars))]

--- a/tz/osemosys/model/variables/storage.py
+++ b/tz/osemosys/model/variables/storage.py
@@ -21,4 +21,7 @@ def add_storage_variables(ds: xr.Dataset, m: Model) -> Model:
 
     m.add_variables(lower=0, upper=inf, coords=RSY, name="NewStorageCapacity", integer=False)
 
+    # New variable: Explicit storage level (state of charge) per timeslice
+    RSYTs = [ds.coords["REGION"], ds.coords["STORAGE"], ds.coords["YEAR"], ds.coords["TIMESLICE"]]
+    m.add_variables(lower=0, upper=inf, coords=RSYTs, name="StorageLevel", integer=False)
     return m


### PR DESCRIPTION
### Description
- Main: 
    - Replaces the dense, horizon-wide cumulative-sum representation of storage state-of-charge (see old formulation here: [storage_gross_cap_old.txt](https://github.com/user-attachments/files/29249653/storage_gross_cap_old.txt)) with an explicit StorageLevel decision variable, pinned by a sparse inter-timeslice recursion (see new formulation here: [storage_gross_cap_refactored.txt](https://github.com/user-attachments/files/29249654/storage_gross_cap_refactored.txt)). Functionally equivalent (same optimum), but converts the storage constraint structure from O(T²) to O(T) in the number of timeslices — a prerequisite for storage to scale to hourly-resolution models.
    -   StorageLevel regression checks:
         - Recursion correctness (level == net.cumsum("YRTS")). StorageLevel is now a free decision variable pinned by StorageLevel[t] = StorageLevel[t-1] + NetCharge[t] (with initial level 0). Integrating that recursion means the level at any timeslice equals the running sum of all prior net charge. The test stacks (YEAR, TIMESLICE) into a single ordered time axis (YRTS) and asserts StorageLevel matches the cumulative NetCharge along it to catch off-by-one, wrong shift direction, or mis-ordered stacking if the recursion is ever altered.
         - Physical bounds (0 ≤ StorageLevel ≤ GrossStorageCapacity). State of charge is a physical energy stock, it can't go negative, and can't exceed installed storage capacity. The two assert checks confirm the floor (the lower=0 variable bound) and the ceiling (StorageGrossCapacitySufficiency). The ±1e-6 tolerances absorb solver floating-point noise.
- Minor: Update pyproject.toml to resolve CI drift (fix for https://github.com/transition-zero/tz-osemosys/pull/186). Include ipykernel for jupyter notebook. Update CI workflow to mark workspace safe for git, full-depth checkout (fix for https://github.com/transition-zero/tz-osemosys/pull/185)

### What changed
- New decision variable StorageLevel[REGION, STORAGE, YEAR, TIMESLICE], lower=0 (state of charge is a physical energy stock cannot go negative; the bound guarantees this structurally although minimum charge default prevents this).
- Sparse recursion defines it instead of a cumsum:
    - StorageLevelRecursion: level[t] − level[t−1] == NetCharge[t] (masked to exclude the first timeslice)
    - StorageLevelStart: level[0] == NetCharge[0] + StorageLevelStart (initial-SoC base case)
- StorageGrossCapacitySufficiency and StorageMinimumCharge now bound the variable directly in unstacked (YEAR, TIMESLICE) space (dropped the obsolete .stack("YRTS") / .fillna(0) that only made sense for the old expression).
- solution.py: removed the special-case that reconstructed StorageLevel via unstack("YRTS") — it's now a first-class solved variable and flows through m.solution directly.
- Update pyproject.toml to address pre-existing dependency problem:
   - Specifiy upper bound for pydantic as pydantic >=2.13 rejects the bare `@field_serializer` used in schemas/technology.py (PydanticUserError: decorator cannot be used without arguments).
   - Specify upper bound for xarray as xarray >=2026 breaks linopy 0.5.5 at Model() construction; 2025.x is known-good.
   - Include ipykernel.


### Checklist
- [x] Dependencies install correctly in a clean environment and code executes;
- [x] Test coverage extended; created tests fail without the change (if possible);
- [x] All tests passing;
- [x] Commits follow a type convention (e.g. https://gist.github.com/brianclements/841ea7bffdb01346392c#type);
- [x] Extended the README, documentation and/or docstrings, if necessary;
