### PR TITLE
Remove timeslice capacity factors from annual planned maintenance con…

### DIFF
--- a/tz/osemosys/model/constraints/capacity_adequacy_b.py
+++ b/tz/osemosys/model/constraints/capacity_adequacy_b.py
@@ -30,23 +30,18 @@ def add_capacity_adequacy_b_constraints(
         r in REGION, t in TECHNOLOGY, y in YEAR: AvailabilityFactor[r,t,y] < 1}:
         sum{l in TIMESLICE} RateOfTotalActivity[r,t,l,y] * YearSplit[l,y]
         <=
-        sum{l in TIMESLICE} (TotalCapacityAnnual[r,t,y] * CapacityFactor[r,t,l,y] *
-        YearSplit[l,y]) * AvailabilityFactor[r,t,y] * CapacityToActivityUnit[r,t];
+        (TotalCapacityAnnual[r,t,y] * AvailabilityFactor[r,t,y]
+        * CapacityToActivityUnit[r,t]);
     ```
     """
 
     mask = ds["AvailabilityFactor"] < 1
     con = (lex["RateOfTotalActivity"] * ds["YearSplit"]).sum(dims="TIMESLICE") - (
         (
-            lex["GrossCapacity"].assign_coords(
-                {"TIMESLICE": ds["CapacityFactor"].coords["TIMESLICE"]}
-            )
-            * ds["CapacityFactor"]
-            * ds["YearSplit"]
-        ).sum(dims="TIMESLICE")
+            lex["GrossCapacity"]
         * ds["AvailabilityFactor"]
         * ds["CapacityToActivityUnit"]
-    ) <= 0
+    )) <= 0
     m.add_constraints(con, name="CAb1_PlannedMaintenance", mask=mask)
 
     return m

--- a/tz/osemosys/model/constraints/capacity_adequacy_b.py
+++ b/tz/osemosys/model/constraints/capacity_adequacy_b.py
@@ -36,12 +36,10 @@ def add_capacity_adequacy_b_constraints(
     """
 
     mask = ds["AvailabilityFactor"] < 1
-    con = (lex["RateOfTotalActivity"] * ds["YearSplit"]).sum(dims="TIMESLICE") - (
-        (
-        lex["GrossCapacity"]
+    con = (lex["RateOfTotalActivity"] * ds["YearSplit"]).sum(dims="TIMESLICE") 
+    - (lex["GrossCapacity"]
         * ds["AvailabilityFactor"]
-        * ds["CapacityToActivityUnit"]
-    )) <= 0
+        * ds["CapacityToActivityUnit"]) <= 0
     m.add_constraints(con, name="CAb1_PlannedMaintenance", mask=mask)
 
     return m

--- a/tz/osemosys/model/constraints/capacity_adequacy_b.py
+++ b/tz/osemosys/model/constraints/capacity_adequacy_b.py
@@ -36,12 +36,9 @@ def add_capacity_adequacy_b_constraints(
     """
 
     mask = ds["AvailabilityFactor"] < 1
-    con = ( 
-    (lex["RateOfTotalActivity"] * ds["YearSplit"]).sum(dims="TIMESLICE") 
-    - (lex["GrossCapacity"]
-        * ds["AvailabilityFactor"]
-        * ds["CapacityToActivityUnit"]) <= 0 
-    )
+    con = (lex["RateOfTotalActivity"] * ds["YearSplit"]).sum(dims="TIMESLICE") - (
+        lex["GrossCapacity"] * ds["AvailabilityFactor"] * ds["CapacityToActivityUnit"]
+    ) <= 0
     m.add_constraints(con, name="CAb1_PlannedMaintenance", mask=mask)
 
     return m

--- a/tz/osemosys/model/constraints/capacity_adequacy_b.py
+++ b/tz/osemosys/model/constraints/capacity_adequacy_b.py
@@ -36,10 +36,12 @@ def add_capacity_adequacy_b_constraints(
     """
 
     mask = ds["AvailabilityFactor"] < 1
-    con = (lex["RateOfTotalActivity"] * ds["YearSplit"]).sum(dims="TIMESLICE") 
+    con = ( 
+    (lex["RateOfTotalActivity"] * ds["YearSplit"]).sum(dims="TIMESLICE") 
     - (lex["GrossCapacity"]
         * ds["AvailabilityFactor"]
-        * ds["CapacityToActivityUnit"]) <= 0
+        * ds["CapacityToActivityUnit"]) <= 0 
+    )
     m.add_constraints(con, name="CAb1_PlannedMaintenance", mask=mask)
 
     return m

--- a/tz/osemosys/model/constraints/capacity_adequacy_b.py
+++ b/tz/osemosys/model/constraints/capacity_adequacy_b.py
@@ -38,7 +38,7 @@ def add_capacity_adequacy_b_constraints(
     mask = ds["AvailabilityFactor"] < 1
     con = (lex["RateOfTotalActivity"] * ds["YearSplit"]).sum(dims="TIMESLICE") - (
         (
-            lex["GrossCapacity"]
+        lex["GrossCapacity"]
         * ds["AvailabilityFactor"]
         * ds["CapacityToActivityUnit"]
     )) <= 0


### PR DESCRIPTION

### Description

- Simple PR removing sub-annual capacity factor parameter from capacity_adequacy_b constraint
- Previously if a non-default (i.e. non-100%) sub-annual CF was being set along with the annual availability factor, a generator couldnt reach its capacity factor because the adequacy_b constraint was scaling CF (summed across timeslices) by the availability factor. 
- This was leading to infeasibilities in the Japan and India models where geothermal and bioenergy/waste plants had capacity factor profiles and non-default (i.e. < 100%) availability factors


