### PR TITLE
Fix Pydantic 2.11 model_fields instance-access deprecation

### DIFF
--- a/tz/osemosys/schemas/commodity.py
+++ b/tz/osemosys/schemas/commodity.py
@@ -109,7 +109,7 @@ class Commodity(OSeMOSYSBase, OtooleCommodity):
         return values
 
     def compose(self, **sets):
-        for field, _info in self.model_fields.items():
+        for field, _info in type(self).model_fields.items():
             field_val = getattr(self, field)
 
             if field_val is not None:

--- a/tz/osemosys/schemas/impact.py
+++ b/tz/osemosys/schemas/impact.py
@@ -142,7 +142,7 @@ class Impact(OSeMOSYSBase, OtooleImpact):
 
     def compose(self, **sets):
         # compose root OSeMOSYSData
-        for field, _info in self.model_fields.items():
+        for field, _info in type(self).model_fields.items():
             field_val = getattr(self, field)
 
             if field_val is not None:

--- a/tz/osemosys/schemas/region.py
+++ b/tz/osemosys/schemas/region.py
@@ -44,7 +44,7 @@ class Region(OSeMOSYSBase, OtooleRegion):
 
     def compose(self, **sets):
         # compose root OSeMOSYSData
-        for field, _info in self.model_fields.items():
+        for field, _info in type(self).model_fields.items():
             field_val = getattr(self, field)
 
             if field_val is not None:
@@ -120,7 +120,7 @@ class RegionGroup(OSeMOSYSBase, OtooleRegionGroup):
 
     def compose(self, **sets):
         # compose root OSeMOSYSData
-        for field, _info in self.model_fields.items():
+        for field, _info in type(self).model_fields.items():
             field_val = getattr(self, field)
 
             if field_val is not None:

--- a/tz/osemosys/schemas/storage.py
+++ b/tz/osemosys/schemas/storage.py
@@ -127,7 +127,7 @@ class Storage(OSeMOSYSBase, OtooleStorage):
 
     def compose(self, **sets):
         # compose root OSeMOSYSData
-        for field, _info in self.model_fields.items():
+        for field, _info in type(self).model_fields.items():
             field_val = getattr(self, field)
 
             if field_val is not None:

--- a/tz/osemosys/schemas/technology.py
+++ b/tz/osemosys/schemas/technology.py
@@ -87,7 +87,7 @@ class OperatingMode(OSeMOSYSBase):
 
     def compose(self, **sets):
         # compose root OSeMOSYSData
-        for field, _info in self.model_fields.items():
+        for field, _info in type(self).model_fields.items():
             field_val = getattr(self, field)
 
             if field_val is not None:
@@ -341,7 +341,7 @@ class Technology(OSeMOSYSBase, OtooleTechnology):
 
     def compose(self, **sets):
         # compose root OSeMOSYSData
-        for field, _info in self.model_fields.items():
+        for field, _info in type(self).model_fields.items():
             field_val = getattr(self, field)
 
             if field_val is not None:

--- a/tz/osemosys/schemas/trade.py
+++ b/tz/osemosys/schemas/trade.py
@@ -181,7 +181,7 @@ class Trade(OSeMOSYSBase, OtooleTrade):
         return self
 
     def compose(self, **sets):
-        for field, _info in self.model_fields.items():
+        for field, _info in type(self).model_fields.items():
             field_val = getattr(self, field)
 
             if field_val is not None:


### PR DESCRIPTION
## What

Pydantic 2.11 deprecated accessing `model_fields` on a model **instance** (and Pydantic 3.0 removes it). This replaces the 8 `self.model_fields` reads in the schema `compose()` methods with `type(self).model_fields`.

Files: `commodity.py`, `impact.py`, `region.py` (×2), `storage.py`, `technology.py` (×2), `trade.py`.

## Why it's safe

- `model_fields` is a **class-level** attribute — class vs instance access returns the same mapping, so behaviour is identical.
- Every affected loop only uses the field **name** (then `getattr(self, field)`); the `FieldInfo` value is discarded.
- The `cls.model_fields` sites (in classmethods) were already correct and are **left untouched**.

## Verification

- `pytest tests/test_construction/` → **35 passed, 2 skipped**; the `PydanticDeprecatedSince211: … 'model_fields' … on the instance` warnings (previously emitted on every model construction) are gone.
- `grep -rn 'self\.model_fields' tz/` → no results.

## Scope

Standalone cleanup, independent of the in-flight linopy 0.7 migration (disjoint files). Completes Pydantic-3.0 readiness for this symbol — no other deprecated instance-access (`__fields__`, `model_computed_fields`) exists in the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)