### PR TITLE
Migrate to linopy 0.9

### DIFF
--- a/bin/memory_profile.py
+++ b/bin/memory_profile.py
@@ -247,7 +247,7 @@ def add_linopy_constraints(
     m = add_re_targets_constraints(ds, m)
     m = add_emissions_constraints(ds, m, discount_factor_mid)
 
-    objective = m["TotalDiscountedCost"].sum(dims=["REGION", "YEAR"])
+    objective = m["TotalDiscountedCost"].sum(dim=["REGION", "YEAR"])
     m.add_objective(expr=objective, overwrite=True)
     return m
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "h5py",
   "xarray<2026",
   "orjson",
-  "linopy==0.5.5",
+  "linopy>=0.9,<0.10",
   "h5netcdf",
 ]
 

--- a/tests/test_solve/test_solve.py
+++ b/tests/test_solve/test_solve.py
@@ -141,7 +141,7 @@ def test_simple_trade():
 
     model.solve(solver_name="highs")
 
-    assert round(model.solution["NetTrade"].values[0][2][0][0], 10) == 24
+    assert round(model.solution["NetTrade"].sel(REGION="R1", YEAR=2022).item(), 10) == 24
     assert np.round(model._m.objective.value) == 35471.0
 
 
@@ -200,7 +200,7 @@ def test_simple_trade_forced_min_activity():
 
     model.solve(solver_name="highs")
 
-    assert round(model.solution["NetTrade"].values[0][2][0][0], 10) == 5
+    assert round(model.solution["NetTrade"].sel(REGION="R1", YEAR=2022).item(), 10) == 5
     assert np.round(model._m.objective.value) == 53417.0
 
 

--- a/tz/osemosys/model/constraints/capacity_adequacy_b.py
+++ b/tz/osemosys/model/constraints/capacity_adequacy_b.py
@@ -36,14 +36,14 @@ def add_capacity_adequacy_b_constraints(
     """
 
     mask = ds["AvailabilityFactor"] < 1
-    con = (lex["RateOfTotalActivity"] * ds["YearSplit"]).sum(dims="TIMESLICE") - (
+    con = (lex["RateOfTotalActivity"] * ds["YearSplit"]).sum(dim="TIMESLICE") - (
         (
             lex["GrossCapacity"].assign_coords(
                 {"TIMESLICE": ds["CapacityFactor"].coords["TIMESLICE"]}
             )
             * ds["CapacityFactor"]
             * ds["YearSplit"]
-        ).sum(dims="TIMESLICE")
+        ).sum(dim="TIMESLICE")
         * ds["AvailabilityFactor"]
         * ds["CapacityToActivityUnit"]
     ) <= 0

--- a/tz/osemosys/model/constraints/re_targets.py
+++ b/tz/osemosys/model/constraints/re_targets.py
@@ -64,7 +64,7 @@ def add_production_target_constraints(
     ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]
 ) -> Model:
     if (mask := ds["TechnologyMinProductionTarget"].notnull()).any():
-        lhs = lex["ProductionByTechnology"].where(mask, drop=True).sum(dims="TIMESLICE")
+        lhs = lex["ProductionByTechnology"].where(mask, drop=True).sum(dim="TIMESLICE")
         rhs = lex["ProductionAnnual"].reindex(lhs.coords) * ds["TechnologyMinProductionTarget"].sel(
             lhs.coords
         )
@@ -75,7 +75,7 @@ def add_production_target_constraints(
         )
 
     if (mask := ds["TechnologyMaxProductionTarget"].notnull()).any():
-        lhs = lex["ProductionByTechnology"].where(mask, drop=True).sum(dims="TIMESLICE")
+        lhs = lex["ProductionByTechnology"].where(mask, drop=True).sum(dim="TIMESLICE")
         rhs = lex["ProductionAnnual"].reindex(lhs.coords) * ds["TechnologyMaxProductionTarget"].sel(
             lhs.coords
         )

--- a/tz/osemosys/model/constraints/storage.py
+++ b/tz/osemosys/model/constraints/storage.py
@@ -345,7 +345,7 @@ def add_storage_constraints(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpre
         if "StorageBalanceYear" in ds.data_vars:
             con = (
                 (lex["RateOfStorageCharge"] - lex["RateOfStorageDischarge"]) * ds["YearSplit"]
-            ).sum(dims="TIMESLICE") == 0
+            ).sum(dim="TIMESLICE") == 0
             mask = ds["StorageBalanceYear"] == 1
             m.add_constraints(con, name="SC10_BalanceAnnualConstraint", mask=mask)
 

--- a/tz/osemosys/model/linear_expressions/activity.py
+++ b/tz/osemosys/model/linear_expressions/activity.py
@@ -5,10 +5,10 @@ from linopy import LinearExpression, Model
 
 
 def add_lex_activity(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]):
-    RateOfTotalActivity = m["RateOfActivity"].sum(dims="MODE_OF_OPERATION")
+    RateOfTotalActivity = m["RateOfActivity"].sum(dim="MODE_OF_OPERATION")
     TotalTechnologyAnnualActivity = (RateOfTotalActivity * ds["YearSplit"]).sum("TIMESLICE")
     TotalAnnualTechnologyActivityByMode = (m["RateOfActivity"] * ds["YearSplit"]).sum("TIMESLICE")
-    TotalTechnologyModelPeriodActivity = TotalTechnologyAnnualActivity.sum(dims="YEAR")
+    TotalTechnologyModelPeriodActivity = TotalTechnologyAnnualActivity.sum(dim="YEAR")
 
     lex.update(
         {

--- a/tz/osemosys/model/linear_expressions/emissions.py
+++ b/tz/osemosys/model/linear_expressions/emissions.py
@@ -11,7 +11,7 @@ def add_lex_emissions(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]
         .where(ds["EmissionActivityRatio"].notnull(), drop=False)
     )
 
-    AnnualTechnologyEmission = AnnualTechnologyEmissionByMode.sum(dims="MODE_OF_OPERATION").where(
+    AnnualTechnologyEmission = AnnualTechnologyEmissionByMode.sum(dim="MODE_OF_OPERATION").where(
         ds["EmissionActivityRatio"].sum("MODE_OF_OPERATION") != 0, drop=False
     )
 
@@ -23,13 +23,11 @@ def add_lex_emissions(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression]
         drop=False,
     )
 
-    AnnualTechnologyEmissionsPenalty = AnnualTechnologyEmissionPenaltyByEmission.sum(
-        dims="EMISSION"
-    )
+    AnnualTechnologyEmissionsPenalty = AnnualTechnologyEmissionPenaltyByEmission.sum(dim="EMISSION")
 
-    AnnualEmissions = AnnualTechnologyEmission.sum(dims="TECHNOLOGY")
+    AnnualEmissions = AnnualTechnologyEmission.sum(dim="TECHNOLOGY")
 
-    ModelPeriodEmissions = AnnualEmissions.sum(dims="YEAR") + ds[
+    ModelPeriodEmissions = AnnualEmissions.sum(dim="YEAR") + ds[
         "ModelPeriodExogenousEmission"
     ].fillna(0)
 

--- a/tz/osemosys/model/linear_expressions/financials.py
+++ b/tz/osemosys/model/linear_expressions/financials.py
@@ -17,7 +17,7 @@ def add_lex_financials(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression
     # costs
     AnnualVariableOperatingCost = (
         (lex["TotalAnnualTechnologyActivityByMode"] * ds["VariableCost"].fillna(0))
-        .sum(dims="MODE_OF_OPERATION")
+        .sum(dim="MODE_OF_OPERATION")
         .where(
             (ds["VariableCost"].sum(dim="MODE_OF_OPERATION") != 0)
             & (~ds["VariableCost"].sum(dim="MODE_OF_OPERATION").isnull()),

--- a/tz/osemosys/model/linear_expressions/production.py
+++ b/tz/osemosys/model/linear_expressions/production.py
@@ -11,21 +11,21 @@ def add_lex_quantities(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpression
     )
     RateOfProductionByTechnology = RateOfProductionByTechnologyByMode.where(
         ds["OutputActivityRatio"].sum("MODE_OF_OPERATION") != 0, drop=False
-    ).sum(dims="MODE_OF_OPERATION")
-    RateOfProduction = RateOfProductionByTechnology.sum(dims="TECHNOLOGY")
+    ).sum(dim="MODE_OF_OPERATION")
+    RateOfProduction = RateOfProductionByTechnology.sum(dim="TECHNOLOGY")
     ProductionByTechnology = RateOfProductionByTechnology * ds["YearSplit"]
     Production = RateOfProduction * ds["YearSplit"]
-    ProductionAnnual = Production.sum(dims="TIMESLICE")
+    ProductionAnnual = Production.sum(dim="TIMESLICE")
 
     RateOfUseByTechnologyByMode = m["RateOfActivity"] * ds["InputActivityRatio"].where(
         ds["InputActivityRatio"].notnull(), drop=False
     )
     RateOfUseByTechnology = RateOfUseByTechnologyByMode.where(
         ds["InputActivityRatio"].sum("MODE_OF_OPERATION") != 0, drop=False
-    ).sum(dims="MODE_OF_OPERATION")
-    RateOfUse = RateOfUseByTechnology.sum(dims="TECHNOLOGY")
+    ).sum(dim="MODE_OF_OPERATION")
+    RateOfUse = RateOfUseByTechnology.sum(dim="TECHNOLOGY")
     Use = RateOfUse * ds["YearSplit"]
-    UseAnnual = Use.sum(dims="TIMESLICE")
+    UseAnnual = Use.sum(dim="TIMESLICE")
 
     lex.update(
         {

--- a/tz/osemosys/model/linear_expressions/re_production.py
+++ b/tz/osemosys/model/linear_expressions/re_production.py
@@ -10,11 +10,11 @@ def add_lex_re_production(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpress
     )
     RateOfProductionByTechnologyRE = RateOfProductionByTechnologyByModeRE.where(
         ds["OutputActivityRatio"].sum("MODE_OF_OPERATION") != 0, drop=False
-    ).sum(dims="MODE_OF_OPERATION")
-    RateOfProductionRE = RateOfProductionByTechnologyRE.sum(dims="TECHNOLOGY")
+    ).sum(dim="MODE_OF_OPERATION")
+    RateOfProductionRE = RateOfProductionByTechnologyRE.sum(dim="TECHNOLOGY")
     ProductionByTechnologyRE = RateOfProductionByTechnologyRE * ds["YearSplit"]
     ProductionRE = RateOfProductionRE * ds["YearSplit"]
-    ProductionAnnualRE = ProductionRE.sum(dims="TIMESLICE")
+    ProductionAnnualRE = ProductionRE.sum(dim="TIMESLICE")
 
     lex.update(
         {

--- a/tz/osemosys/model/linear_expressions/regiongroup.py
+++ b/tz/osemosys/model/linear_expressions/regiongroup.py
@@ -16,11 +16,11 @@ def add_lex_regiongroup(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpressio
     )
 
     AnnualTechnologyEmissionRegionGroup = AnnualTechnologyEmissionByModeRegionGroup.sum(
-        dims="MODE_OF_OPERATION"
+        dim="MODE_OF_OPERATION"
     ).where(ds["EmissionActivityRatio"].sum("MODE_OF_OPERATION") != 0, drop=False)
 
-    AnnualEmissionsRegionGroupTag = AnnualTechnologyEmissionRegionGroup.sum(dims="TECHNOLOGY")
-    AnnualEmissionsRegionGroup = AnnualEmissionsRegionGroupTag.sum(dims="REGION")
+    AnnualEmissionsRegionGroupTag = AnnualTechnologyEmissionRegionGroup.sum(dim="TECHNOLOGY")
+    AnnualEmissionsRegionGroup = AnnualEmissionsRegionGroupTag.sum(dim="REGION")
 
     # PRODUCTION
 
@@ -29,12 +29,12 @@ def add_lex_regiongroup(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpressio
     )
     RateOfProductionByTechnologyRegionGroup = RateOfProductionByTechnologyByModeRG.where(
         ds["OutputActivityRatio"].sum("MODE_OF_OPERATION") != 0, drop=False
-    ).sum(dims="MODE_OF_OPERATION")
-    RateOfProductionRegionGroup = RateOfProductionByTechnologyRegionGroup.sum(dims="TECHNOLOGY")
+    ).sum(dim="MODE_OF_OPERATION")
+    RateOfProductionRegionGroup = RateOfProductionByTechnologyRegionGroup.sum(dim="TECHNOLOGY")
     ProductionByTechnologyRegionGroup = RateOfProductionByTechnologyRegionGroup * ds["YearSplit"]
     ProductionRegionGroup = RateOfProductionRegionGroup * ds["YearSplit"]
-    ProductionAnnualRegionGroup = ProductionRegionGroup.sum(dims="TIMESLICE")
-    ProductionAnnualRegionGroupAggregate = ProductionAnnualRegionGroup.sum(dims="REGION").where(
+    ProductionAnnualRegionGroup = ProductionRegionGroup.sum(dim="TIMESLICE")
+    ProductionAnnualRegionGroupAggregate = ProductionAnnualRegionGroup.sum(dim="REGION").where(
         ds["RegionGroupTagRegion"] == 1, drop=False
     )
 
@@ -47,14 +47,14 @@ def add_lex_regiongroup(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpressio
     )
     RateOfProductionByTechnologyRERegionGroup = RateOfProductionByTechnologyByModeRERG.where(
         ds["OutputActivityRatio"].sum("MODE_OF_OPERATION") != 0, drop=False
-    ).sum(dims="MODE_OF_OPERATION")
-    RateOfProductionRERegionGroup = RateOfProductionByTechnologyRERegionGroup.sum(dims="TECHNOLOGY")
+    ).sum(dim="MODE_OF_OPERATION")
+    RateOfProductionRERegionGroup = RateOfProductionByTechnologyRERegionGroup.sum(dim="TECHNOLOGY")
     ProductionByTechnologyRERegionGroup = (
         RateOfProductionByTechnologyRERegionGroup * ds["YearSplit"]
     )
     ProductionRERegionGroup = RateOfProductionRERegionGroup * ds["YearSplit"]
-    ProductionAnnualRERegionGroup = ProductionRERegionGroup.sum(dims="TIMESLICE")
-    ProductionAnnualRERegionGroupAggregate = ProductionAnnualRERegionGroup.sum(dims="REGION").where(
+    ProductionAnnualRERegionGroup = ProductionRERegionGroup.sum(dim="TIMESLICE")
+    ProductionAnnualRERegionGroupAggregate = ProductionAnnualRERegionGroup.sum(dim="REGION").where(
         ds["RegionGroupTagRegion"] == 1, drop=False
     )
 

--- a/tz/osemosys/model/linear_expressions/reserve_margin.py
+++ b/tz/osemosys/model/linear_expressions/reserve_margin.py
@@ -33,7 +33,7 @@ def add_lex_reserve_margin(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpres
             & (ds["ReserveMarginTagFuel"] == 1)
             & (ds["ReserveMarginTagTechnology"] > 0),
             drop=False,
-        ).sum(dims="MODE_OF_OPERATION")
+        ).sum(dim="MODE_OF_OPERATION")
     )
 
     RateOfProductionWithReserveMargin = RateOfProductionByTechnologyWithReserveMargin.where(
@@ -42,7 +42,7 @@ def add_lex_reserve_margin(ds: xr.Dataset, m: Model, lex: Dict[str, LinearExpres
         & (ds["ReserveMarginTagFuel"] == 1)
         & (ds["ReserveMarginTagTechnology"] > 0),
         drop=False,
-    ).sum(dims="TECHNOLOGY")
+    ).sum(dim="TECHNOLOGY")
 
     DemandNeedingReserveMargin = (
         (lex["RateOfProduction"] * ds["ReserveMarginTagFuel"])

--- a/tz/osemosys/model/objective.py
+++ b/tz/osemosys/model/objective.py
@@ -2,7 +2,7 @@ from linopy import LinearExpression, Model
 
 
 def add_objective(m: Model, lex: dict[str, LinearExpression]) -> float:
-    objective = lex["TotalDiscountedCost"].sum(dims=["REGION", "YEAR"])
+    objective = lex["TotalDiscountedCost"].sum(dim=["REGION", "YEAR"])
 
     # constants not currently supported in objective functions:
     # https://github.com/PyPSA/linopy/issues/236

--- a/tz/osemosys/model/variables/activity.py
+++ b/tz/osemosys/model/variables/activity.py
@@ -19,18 +19,18 @@ def add_activity_variables(ds: xr.Dataset, m: Model) -> Model:
     """
     # Add indices
     RRTiFY = [
-        ds.coords["REGION"],
-        ds.coords["_REGION"],
-        ds.coords["TIMESLICE"],
-        ds.coords["FUEL"],
-        ds.coords["YEAR"],
+        ds.indexes["REGION"],
+        ds.indexes["_REGION"],
+        ds.indexes["TIMESLICE"],
+        ds.indexes["FUEL"],
+        ds.indexes["YEAR"],
     ]
     RTeMYTi = [
-        ds.coords["REGION"],
-        ds.coords["TECHNOLOGY"],
-        ds.coords["MODE_OF_OPERATION"],
-        ds.coords["YEAR"],
-        ds.coords["TIMESLICE"],
+        ds.indexes["REGION"],
+        ds.indexes["TECHNOLOGY"],
+        ds.indexes["MODE_OF_OPERATION"],
+        ds.indexes["YEAR"],
+        ds.indexes["TIMESLICE"],
     ]
 
     mask = (

--- a/tz/osemosys/model/variables/capacity.py
+++ b/tz/osemosys/model/variables/capacity.py
@@ -18,8 +18,8 @@ def add_capacity_variables(ds: xr.Dataset, m: Model) -> Model:
     linopy.Model
     """
     # Create the required index
-    RTeY = [ds.coords["REGION"], ds.coords["TECHNOLOGY"], ds.coords["YEAR"]]
-    RRFY = [ds.coords["REGION"], ds.coords["_REGION"], ds.coords["FUEL"], ds.coords["YEAR"]]
+    RTeY = [ds.indexes["REGION"], ds.indexes["TECHNOLOGY"], ds.indexes["YEAR"]]
+    RRFY = [ds.indexes["REGION"], ds.indexes["_REGION"], ds.indexes["FUEL"], ds.indexes["YEAR"]]
 
     # masks
     mask = ds["CapacityOfOneTechnologyUnit"].notnull()

--- a/tz/osemosys/model/variables/storage.py
+++ b/tz/osemosys/model/variables/storage.py
@@ -22,6 +22,11 @@ def add_storage_variables(ds: xr.Dataset, m: Model) -> Model:
     m.add_variables(lower=0, upper=inf, coords=RSY, name="NewStorageCapacity", integer=False)
 
     # New variable: Explicit storage level (state of charge) per timeslice
-    RSYTs = [ds.indexes["REGION"], ds.indexes["STORAGE"], ds.indexes["YEAR"], ds.indexes["TIMESLICE"]]
+    RSYTs = [
+        ds.indexes["REGION"],
+        ds.indexes["STORAGE"],
+        ds.indexes["YEAR"],
+        ds.indexes["TIMESLICE"],
+    ]
     m.add_variables(lower=0, upper=inf, coords=RSYTs, name="StorageLevel", integer=False)
     return m

--- a/tz/osemosys/model/variables/storage.py
+++ b/tz/osemosys/model/variables/storage.py
@@ -17,11 +17,11 @@ def add_storage_variables(ds: xr.Dataset, m: Model) -> Model:
     -------
     linopy.Model
     """
-    RSY = [ds.coords["REGION"], ds.coords["STORAGE"], ds.coords["YEAR"]]
+    RSY = [ds.indexes["REGION"], ds.indexes["STORAGE"], ds.indexes["YEAR"]]
 
     m.add_variables(lower=0, upper=inf, coords=RSY, name="NewStorageCapacity", integer=False)
 
     # New variable: Explicit storage level (state of charge) per timeslice
-    RSYTs = [ds.coords["REGION"], ds.coords["STORAGE"], ds.coords["YEAR"], ds.coords["TIMESLICE"]]
+    RSYTs = [ds.indexes["REGION"], ds.indexes["STORAGE"], ds.indexes["YEAR"], ds.indexes["TIMESLICE"]]
     m.add_variables(lower=0, upper=inf, coords=RSYTs, name="StorageLevel", integer=False)
     return m


### PR DESCRIPTION
## What

Moves tz-osemosys from `linopy==0.5.5` to `linopy>=0.9,<0.10` (latest linopy). This is the cross-repo prerequisite for the tz-mod PyPSA v1 / linopy 0.9 upgrade.

> Target updated from linopy 0.7 → **0.9**: 0.7.x had a single release and is already superseded (0.8, 0.9); pypsa's development branch already requires `linopy>=0.8.0`, so 0.7 would be an immediate dead-end. Going to 0.9 adds only the `add_variables` coords change below.

## Changes

- **`pyproject.toml`**: `linopy==0.5.5` → `linopy>=0.9,<0.10`.
- **`.sum(dims=…)` → `.sum(dim=…)`** — 35 shipping-code sites + 1 in `bin/memory_profile.py` (linopy aligned the kwarg with xarray). The `xr.DataArray(…, dims="YRTS")` constructor in `constraints/storage.py` is intentionally unchanged.
- **`add_variables` coords (linopy 0.8+)** — linopy no longer accepts xarray `DataArray` coord entries; it requires a `pd.Index`. Changed `ds.coords[...]` → `ds.indexes[...]` in the coordinate lists in `variables/{activity,capacity,storage}.py` (6 lists, 3 files).
- **Trade solve tests** — linopy changed the solved `NetTrade` solution dim order to `(REGION, TIMESLICE, FUEL, YEAR)`, so the old positional `.values[0][2][0][0]` walked off an axis (`IndexError`). `test_simple_trade` / `test_simple_trade_forced_min_activity` now use order-independent labelled access: `.sel(REGION="R1", YEAR=2022).item()`.

## Verification

Full suite on **linopy 0.9.0**: **90 passed, 2 skipped**. (Also verified green on 0.7.0 earlier; the `mask=` breakage anticipated for 0.8+ did not materialise.)

## Notes

- The Pydantic 2.11 `model_fields` deprecation is handled separately in #190 (disjoint files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)